### PR TITLE
vsock: defer credit updates

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -44,7 +44,8 @@ CFLAGS_WARN := \
   -Wno-padded \
   -Wno-reserved-id-macro \
   -Wno-unknown-warning-option \
-  -Wno-unused-macros
+  -Wno-unused-macros \
+  -Wno-vla
 
 CFLAGS_DIAG := \
   -fmessage-length=152 \

--- a/src/lib/pci_virtio_sock.c
+++ b/src/lib/pci_virtio_sock.c
@@ -1762,7 +1762,7 @@ static int is_socket_config_malformed(struct vtsock_config_hdr *hdr)
 	case TYPE: if (hdr->len < hdr_sz + sizeof(CTYPE)) {		\
 		fprintf(stderr, "config: ERROR "			\
 			#TYPE " message too short for " #CTYPE		\
-			" (%d < %lu)\n",				\
+			" (%d < %zu)\n",				\
 			hdr->len, hdr_sz + sizeof(CTYPE));		\
 		return 1;						\
 	} else break;
@@ -1845,7 +1845,7 @@ static void handle_socket_config(struct pci_vtsock_sock *s, int fd)
 
 	if (sz < sizeof(struct vtsock_config_hdr)) {
 		fprintf(stderr, "config: ERROR "
-			"message length %d is less than header size %lu\n",
+			"message length %d is less than header size %zu\n",
 			sz, sizeof(struct vtsock_config_hdr));
 		return;
 	}

--- a/src/lib/pci_virtio_sock.c
+++ b/src/lib/pci_virtio_sock.c
@@ -1880,7 +1880,8 @@ static ssize_t readrx(struct pci_vtsock_sock *s,
 
 	len = recvmsg(s->fd, &msghdr, 0);
 	if (s->configurable && len > 0 && msghdr.msg_controllen > 0) {
-		fprintf(stderr, "config: received configuration request\n");
+		fprintf(stderr, "config: %s received configuration request\n",
+			s->name);
 		cmsg = CMSG_FIRSTHDR(&msghdr);
 		if (cmsg->cmsg_level == SOL_SOCKET
 		    && cmsg->cmsg_type == SCM_RIGHTS) {

--- a/src/lib/pci_virtio_sock.c
+++ b/src/lib/pci_virtio_sock.c
@@ -137,6 +137,7 @@ struct vtsock_config_hdr {
 };
 
 #define VSOCK_CONFIG_SET_BUF_ALLOC 1
+#define VSOCK_CONFIG_SET_CREDIT_LIMIT 2
 
 struct vsock_addr {
 	uint64_t cid;
@@ -263,6 +264,7 @@ struct pci_vtsock_sock {
 
 	uint32_t buf_alloc;
 	uint32_t fwd_cnt;
+	uint32_t credit_limit;
 
 	bool credit_update_required;
 	uint32_t rx_cnt; /* Amount we have sent to the peer */
@@ -640,6 +642,7 @@ static struct pci_vtsock_sock *alloc_sock(struct pci_vtsock_softc *sc)
 
 	s->buf_alloc = DEFAULT_WRITE_BUF_LENGTH;
 	s->fwd_cnt = 0;
+	s->credit_limit = 0;
 
 	s->peer_buf_alloc = 0;
 	s->peer_fwd_cnt = 0;
@@ -1713,6 +1716,11 @@ static void apply_socket_config(struct pci_vtsock_sock *s, void *buf)
 	switch (hdr->type) {
 	case VSOCK_CONFIG_SET_BUF_ALLOC:
 		apply_socket_config_set_buf_alloc(s, *(uint32_t *)(hdr + 1));
+		break;
+	case VSOCK_CONFIG_SET_CREDIT_LIMIT:
+		s->credit_limit = *(uint32_t *)(hdr + 1);
+		fprintf(stderr, "config: %s credit limit = %d\n", s->name,
+			*(uint32_t *)(hdr + 1));
 		break;
 	default:
 		fprintf(stderr, "config: ERROR "

--- a/src/lib/pci_virtio_sock.c
+++ b/src/lib/pci_virtio_sock.c
@@ -196,7 +196,7 @@ struct pci_vtsock_sock {
 	 * |
 	 * |   Note that an RX kick is needed
 	 * |
-         * | Release list_rwlock
+	 * | Release list_rwlock
 	 * |
 	 * `-Kick the rx thread if required
 	 *
@@ -209,7 +209,7 @@ struct pci_vtsock_sock {
 	 * |
 	 * |   Put the socket on a local "to be closed" queue
 	 * |
-         * | Release list_rwlock
+	 * | Release list_rwlock
 	 * |
 	 * | If there a sockets to be closed, take list_rwlock for
 	 * | writing, and for each socket:
@@ -1497,7 +1497,7 @@ static void *pci_vtsock_tx_thread(void *vsc)
 				if (sock_is_buffering(s))
 					break;
 
-			        /* Close down */
+				/* Close down */
 				assert(s->local_shutdown == VIRTIO_VSOCK_FLAG_SHUTDOWN_ALL ||
 				       s->peer_shutdown == VIRTIO_VSOCK_FLAG_SHUTDOWN_ALL);
 


### PR DESCRIPTION
This patchset introduces two new and related features:

1. Per-vsock run-time configuration by host processes via a UNIX domain socket attached fd channel
2. Limit-based credit update elision which significantly reduces the number of messages and interrupts for RPC-like protocols

The credit limit feature relies on the run-time socket configuration feature for opt-in.

In casual benchmarking, this reduces HyperKit CPU usage by 10-15% and increases throughput by ~10% under a small sequential write workload.

The configuration system is described in the commit message of af56e12:

> If messages with attached fds are sent to an AF_UNIX socket that proxies
an AF_VSOCK connection, they are treated as configuration RPC
requests. RX thread activity will block until the configuration request
is applied. The passed fd is valid for a single use in which the
requesting process writes a configuration message and, if appropriate, a
reply is written back. Once the configuration request is processed, the
fd is closed.
>
> This commit introduces version 1 of the configuration protocol that
currently has a message format that looks like:
```c
struct vtsock_config_hdr {
       uint32_t len;
       uint32_t version;
       uint32_t type;
};
```

The credit limit system is described in the commit message of 7d576c7:

> This introduces the sock->credit_cnt field that tracks the device's
understanding of the driver's peer_fwd_cnt (sock->fwd_cnt). When a
credit update may be necessary, the difference between the device's
sock->fwd_cnt and sock->credit_cnt is compared to sock->credit_limit
and, if this safe disparity is sufficiently small, no credit update is
performed and the driver believes that it has less remote buffer than it
actually does. A credit limit of zero maintains the previous behavior of
sending credit updates frequently.
>
> As normal data packets (RW) contain buf_alloc and fwd_cnt fields, this
credit limit functionality can completely elide credit updates for
sequential RPC protocols.
>
> In the case of an explicitly requested credit update, the
sock->credit_cnt is fudged to immediately trigger repayment via a credit
update message.

Please review carefully.