### PR TITLE
Update to latest qcow and mirage-block-unix

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ via `brew` and using `opam` to install the appropriate libraries:
     $ brew install opam libev
     $ opam init
     $ eval `opam config env`
-    $ opam install uri qcow.0.8.1 mirage-block-unix.2.6.0 conf-libev logs fmt mirage-unix
+    $ opam install uri qcow.0.9.5 mirage-block-unix.2.7.0 conf-libev logs fmt mirage-unix
 
 Notes:
 

--- a/circle.yml
+++ b/circle.yml
@@ -17,7 +17,7 @@ test:
     - make test
     - brew install opam libev
     - opam init --yes
-    - opam install --yes uri qcow.0.8.1 mirage-block-unix.2.6.0 ocamlfind conf-libev logs fmt mirage-unix
+    - opam install --yes uri qcow.0.9.5 mirage-block-unix.2.7.0 ocamlfind conf-libev logs fmt mirage-unix
     - make clean
     - eval `opam config env` && make all
     - make test

--- a/test/test_linux_qcow.exp
+++ b/test/test_linux_qcow.exp
@@ -4,7 +4,16 @@ set KERNEL "./vmlinuz"
 set INITRD "./initrd.gz"
 set CMDLINE "earlyprintk=serial console=ttyS0"
 
-exec qcow-tool create --size 1GiB disk.qcow2
+spawn qcow-tool create --size 1GiB disk.qcow2
+set pid [exp_pid]
+set timeout 20
+
+expect {
+  timeout {puts "FAIL qcow-tool"; exec kill -9 $pid; exit 1}
+  -re {Resized file to [0-9]+ clusters \([0-9]+ sectors\)} { }
+  default {puts "\n\nFAIL failed to create disk"; exit 1 }
+}
+
 set PWD [ exec pwd ]
 
 spawn ../build/hyperkit -A -m 512M -s 0:0,hostbridge -s 31,lpc -l com1,stdio -s 1:0,ahci-hd,file:///$PWD/disk.qcow2,format=qcow -f kexec,$KERNEL,$INITRD,$CMDLINE


### PR DESCRIPTION
# mirage-block-unix changes

## 2.7.0 (2017-02-19)
- add a simple file copy benchmark
- add bindings for readv, writev
- cache the file offset and avoid unnecessary calls to lseek

# Qcow changes

## 0.9.5 (2017-03-12)
- CLI: `check` and `sha` will nolonger resize the file as a side-effect
  (#84)
- Allow the number of `cluster_bits` to be set in `create`

## 0.9.4 (2017-03-07)
- Strictly enforce the cluster move state machine
- Don't start moving new blocks while existing moves are in progress
  (fix bug where the same destination block could be reused)
- Hold a lock to exclude `flush` while updating references to ensure
  reference updates hit the disk before the move is considered complete
- Simplify allocator by always adding blocks to the Roots set before
  returning. The caller must transfer them somewhere else.
- Simplify the cluster moving API by combining `get_moves` with
  `start_moves`, so it's not possible to block and affect the moves
  which can legally be started
- When detecting a duplicate reference or hitting an I/O error, log
  analysis of the internal state
- Check for move cancellation before copying a block to avoid accidentally
  copying a block which is now outside the file
- Avoid adding a cluster to the Junk set twice during a reference update
- Add lots of assertions

## 0.9.3 (2017-03-02)
- Hold a read lock on the L1 during read/write
- Minimise locking while updating references
- When moving an L2 cluster, update the cluster map

## 0.9.2 (2017-02-26)
- Don't hold the global lock while updating references
- Log an error if a client I/O takes more than 30s
- Improve the performance of discard by writing each L2 cluster to disk
  only once
- Track clusters which are being erased and copied into, to prevent the
  file being shrunk, orphaning them (which typically manifests as a later
  double-allocation)

## 0.9.1 (2017-02-25)
- Add configuration `runtime_assert` to check GC invariants at runtime
- Use tail-recursive calls in the block recycler (which deals with large
  block lists)
- Wait for the compaction work list to stabilise before processing it
  (otherwise we move blocks which are then immediately discarded)
- Track the difference between blocks on the end of the file being full
  of zeroes due to ftruncate versus being full of junk due to discard
- On open, truncate the file to erase trailing junk
- Don't try to use free space between header structures for user data
  since we assume all blocks after the start of free space are movable
  and header blocks aren't (in this implementation)
- Make cluster locks recursive, hold relevant metadata read locks while
  reading or writing data clusters to ensure they aren't moved while
  we're using them.
- Add a debug testing mode and use it in a test case to verify that
  compact mid-write works as expected.

## 0.9.0 (2017-02-21)
- Add online coalescing mode and background cluster recycling thread
- Rename internal modules and types
- Ensure the interval tree remains balanced to improve performance