### PR TITLE
Circleci artifacts work on macOS 10.10

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -10,6 +10,7 @@ machine:
     GOPATH: "$HOME/go"
     PROJECT_ROOT: "$GOPATH/src/github.com/docker/hyperkit"
     PATH: "${PATH}:${GOPATH}/bin"
+    MACOSX_DEPLOYMENT_TARGET: "10.10"
 test:
   override:
     - make clean


### PR DESCRIPTION
Circleci binary was not compatible with macOS 10.10. In Docker for Mac, we need to support this version (at least for some weeks).