### PR TITLE
circleci: upgrade xcode from 7.3 to 9.0

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -5,7 +5,7 @@ general:
     - build/LICENSE
 machine:
   xcode:
-    version: "7.3"
+    version: "9.0"
   environment:
     GOPATH: "$HOME/go"
     PROJECT_ROOT: "$GOPATH/src/github.com/moby/hyperkit"

--- a/circle.yml
+++ b/circle.yml
@@ -29,6 +29,7 @@ test:
     # Go related steps
     - mkdir -p $(dirname "$PROJECT_ROOT")
     - ln -s $(pwd) "$PROJECT_ROOT"
+    - brew install golang
     - (cd go; make ci)
     # LICENSE related steps
     - find src -type f | xargs awk '/^\/\*-/{p=1;print FILENAME ":";print;next} p&&/^.*\*\//{print;print "";p=0};p' > build/LICENSE

--- a/test/tinycore.sh
+++ b/test/tinycore.sh
@@ -4,7 +4,7 @@ set -e
 # These are binaries from a mirror of
 #  http://tinycorelinux.net
 # with the following patch applied:
-# Upstream source is available http://www.tinycorelinux.net/6.x/x86/release/src/
+# Upstream source is available http://www.tinycorelinux.net/8.x/x86/release/src/
 #BASE_URL="http://www.tinycorelinux.net/"
 
 BASE_URL="http://distro.ibiblio.org/tinycorelinux/"
@@ -13,8 +13,8 @@ TMP_DIR=$(mktemp -d -t hyperkit)
 INITRD_DIR="${TMP_DIR}"/initrd
 
 echo Downloading tinycore linux
-curl -s -o vmlinuz "${BASE_URL}/6.x/x86/release/distribution_files/vmlinuz64"
-curl -s -o "${TMP_DIR}"/initrd.gz "${BASE_URL}/6.x/x86/release/distribution_files/core.gz"
+curl -s -o vmlinuz "${BASE_URL}/8.x/x86/release/distribution_files/vmlinuz64"
+curl -s -o "${TMP_DIR}"/initrd.gz "${BASE_URL}/8.x/x86/release/distribution_files/core.gz"
 
 mkdir "${INITRD_DIR}"
 ( cd "${INITRD_DIR}"; gzip -dc "${TMP_DIR}"/initrd.gz | sudo cpio -idm )


### PR DESCRIPTION
This includes a more recent version of clang.

Signed-off-by: David Scott <dave.scott@docker.com>