### PR TITLE
virtio-vpnkit: remove the strict remote version check

### DIFF
--- a/src/lib/pci_virtio_net_vpnkit.c
+++ b/src/lib/pci_virtio_net_vpnkit.c
@@ -317,11 +317,6 @@ static int vpnkit_connect(int fd, const char uuid[36], struct vif_info *vif)
 			init_reply.magic[4]);
 		return -1;
 	}
-	if (init_reply.version != 1) {
-		fprintf(stderr, "virtio-net-vpnkit: bad init version %d\n",
-			init_reply.version);
-		return -1;
-	}
 
 	fprintf(stderr, "virtio-net-vpnkit: magic=%c%c%c%c%c version=%d commit=%*s\n",
 		init_reply.magic[0], init_reply.magic[1],


### PR DESCRIPTION
Previously we would fail if the remote server didn't report a version of exactly 1. In practice this protocol has evolved only by extension, with new command types being added. All known versions support the "ethernet" command that we need.

This patch removes the strict check of the remote vpnkit protocol version. This allows `hyperkit` to connect to the `com.docker.vmnetd` daemon which comes with Docker for Mac (as well as `vpnkit`)

Signed-off-by: David Scott <dave.scott@docker.com>