### PR TITLE
qcow: add an optional qcow-stats-config= argument

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ FIRMWARE_LIB_SRC := \
 
 HYPERKIT_SRC := src/hyperkit.c
 
-HAVE_OCAML_QCOW := $(shell if ocamlfind query qcow uri logs logs.fmt mirage-unix >/dev/null 2>/dev/null ; then echo YES ; else echo NO; fi)
+HAVE_OCAML_QCOW := $(shell if ocamlfind query qcow prometheus-app uri logs logs.fmt mirage-unix >/dev/null 2>/dev/null ; then echo YES ; else echo NO; fi)
 
 ifeq ($(HAVE_OCAML_QCOW),YES)
 CFLAGS += -DHAVE_OCAML=1 -DHAVE_OCAML_QCOW=1 -DHAVE_OCAML=1
@@ -105,7 +105,7 @@ OCAML_C_SRC := \
 OCAML_WHERE := $(shell ocamlc -where)
 OCAML_PACKS := cstruct cstruct.lwt io-page io-page.unix uri mirage-block \
 	mirage-block-unix qcow unix threads lwt lwt.unix logs logs.fmt   \
-	mirage-unix
+	mirage-unix prometheus-app conduit.lwt cohttp.lwt
 OCAML_LDLIBS := -L $(OCAML_WHERE) \
 	$(shell ocamlfind query cstruct)/cstruct.a \
 	$(shell ocamlfind query cstruct)/libcstruct_stubs.a \

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ via `brew` and using `opam` to install the appropriate libraries:
     $ brew install opam libev
     $ opam init
     $ eval `opam config env`
-    $ opam install uri qcow.0.10.0 qcow-tool mirage-block-unix.2.7.0 conf-libev logs fmt mirage-unix
+    $ opam install uri qcow.0.10.0 qcow-tool mirage-block-unix.2.7.0 conf-libev logs fmt mirage-unix prometheus-app
 
 Notes:
 

--- a/circle.yml
+++ b/circle.yml
@@ -19,7 +19,7 @@ test:
     - make test
     - brew install opam libev
     - opam init --yes
-    - opam install --yes uri qcow.0.10.0 qcow-tool mirage-block-unix.2.7.0 ocamlfind conf-libev logs fmt mirage-unix
+    - opam install --yes uri qcow.0.10.0 qcow-tool mirage-block-unix.2.7.0 ocamlfind conf-libev logs fmt mirage-unix prometheus-app
     - make clean
     - eval `opam config env` && make all
     - make test

--- a/src/lib/block_if.c
+++ b/src/lib/block_if.c
@@ -563,6 +563,7 @@ blockif_open(const char *optstr, const char *ident)
 
 #ifdef HAVE_OCAML_QCOW
 	char *mirage_qcow_config = NULL;
+	char *mirage_qcow_stats_config = NULL;
 	struct mirage_block_stat msbuf;
 #endif
 
@@ -597,6 +598,8 @@ blockif_open(const char *optstr, const char *ident)
 			use_mirage = 1;
 		else if (strncmp(cp, "qcow-config=", 12) == 0)
 			mirage_qcow_config = cp + 12;
+		else if (strncmp(cp, "qcow-stats-config=", 18) == 0)
+			mirage_qcow_stats_config = cp + 18;
 #endif
 		else if (sscanf(cp, "sectorsize=%d/%d", &ssopt, &pssopt) == 2)
 			;
@@ -622,7 +625,7 @@ blockif_open(const char *optstr, const char *ident)
 	if (use_mirage) {
 #ifdef HAVE_OCAML_QCOW
 		mirage_block_register_thread();
-		mbh = mirage_block_open(nopt, mirage_qcow_config);
+		mbh = mirage_block_open(nopt, mirage_qcow_config, mirage_qcow_stats_config);
 		if (mbh < 0) {
 			perror("Could not open mirage-block device");
 			goto err;

--- a/src/lib/mirage_block_c.c
+++ b/src/lib/mirage_block_c.c
@@ -46,19 +46,26 @@ if (fn == NULL) { \
 	acquiring the runtime lock. */
 
 static void
-ocaml_mirage_block_open(const char *config, const char *options, int *out, int *err) {
+ocaml_mirage_block_open(const char *device, const char *qcow_config, const char *stats_config, int *out, int *err) {
 	CAMLparam0();
-	CAMLlocal4(ocaml_config, ocaml_options_opt, ocaml_string, handle);
-	ocaml_config = caml_copy_string(config);
-	if (options == NULL) {
-		ocaml_options_opt = Val_int(0); /* None */
+	CAMLlocal5(ocaml_device, ocaml_qcow_config, ocaml_stats_config, ocaml_string, handle);
+	ocaml_device = caml_copy_string(device);
+	if (qcow_config == NULL) {
+		ocaml_qcow_config = Val_int(0); /* None */
 	} else {
-		ocaml_string = caml_copy_string(options);
-		ocaml_options_opt = caml_alloc(1, 0); /* Some */
-		Store_field (ocaml_options_opt, 0, ocaml_string);
+		ocaml_string = caml_copy_string(qcow_config);
+		ocaml_qcow_config = caml_alloc(1, 0); /* Some */
+		Store_field (ocaml_qcow_config, 0, ocaml_string);
+	}
+	if (stats_config == NULL) {
+		ocaml_stats_config = Val_int(0); /* None */
+	} else {
+		ocaml_string = caml_copy_string(stats_config);
+		ocaml_stats_config = caml_alloc(1, 0); /* Some */
+		Store_field (ocaml_stats_config, 0, ocaml_string);
 	}
 	OCAML_NAMED_FUNCTION("mirage_block_open")
-	handle = caml_callback2_exn(*fn, ocaml_config, ocaml_options_opt);
+	handle = caml_callback3_exn(*fn, ocaml_device, ocaml_qcow_config, ocaml_stats_config);
 	if (Is_exception_result(handle)){
 		*err = 1;
 	} else {
@@ -69,11 +76,11 @@ ocaml_mirage_block_open(const char *config, const char *options, int *out, int *
 }
 
 mirage_block_handle
-mirage_block_open(const char *config, const char *options) {
+mirage_block_open(const char *device, const char *qcow_config, const char *stats_config) {
 	int result;
 	int err = 1;
 	caml_acquire_runtime_system();
-	ocaml_mirage_block_open(config, options, &result, &err);
+	ocaml_mirage_block_open(device, qcow_config, stats_config, &result, &err);
 	caml_release_runtime_system();
 	if (err){
 		errno = EINVAL;

--- a/src/lib/mirage_block_c.h
+++ b/src/lib/mirage_block_c.h
@@ -31,10 +31,12 @@ mirage_block_unregister_thread(void);
 /* An opened mirage-block device */
 typedef int mirage_block_handle;
 
-/* Open a mirage block device with the given optional string configuration.
-   To use the default configuration, pass NULL for options. */
+/* Open a mirage block device with the given optional qcow and stats
+   configuration.
+   To use the default configuration, pass NULL for qcow_config.
+   To not expose stats, pass NULL for stats_config */
 extern mirage_block_handle
-mirage_block_open(const char *config, const char *options);
+mirage_block_open(const char *device, const char *qcow_config, const char *stats_config);
 
 struct mirage_block_stat {
 	int candelete;      /* 1 if the device supports TRIM/DELETE/DISCARD */


### PR DESCRIPTION
The qcow library gathers a set of metrics in prometheus format including

- read, write, discard rate
- bytes used, file size
- bytes erased, deallocated and in various GC states

It's useful to be able to expose these for monitoring, see for example the Grafana dashboard here:

  https://github.com/mirage/ocaml-qcow/issues/99

This patch adds an optional `qcow-stats-config=` argument which supports values

- `unix:/path/to/socket` -- listen on a Unix domain socket
- `tcp:port` -- listen on `0.0.0.0:port`

(unfortunately the Mirage `conduit` library doesn't allow the bind address to be customised, so care must be taken with the `tcp:` option)

By default nothing is exposed.

Signed-off-by: David Scott <dave.scott@docker.com>