### PR TITLE
go lib: Add support for 9p sockets

### DIFF
--- a/go/sample/main.go
+++ b/go/sample/main.go
@@ -46,6 +46,8 @@ func main() {
 	vsock := flag.Bool("vsock", false, "Enable virtio-sockets")
 	vsockports := flag.String("vsock-ports", "", "Comma separated list of ports to expose as sockets from guest")
 
+	_9psock := flag.String("9p-socket", "", "9P unix domain socket to forward to the guest. Format: socket_path,9p_tag")
+
 	iso := flag.String("iso", "", "ISO image to pass to the VM (not for booting from)")
 
 	flag.Parse()
@@ -101,6 +103,14 @@ func main() {
 	}
 	h.DiskImage = *disk
 	h.ISOImage = *iso
+
+	if *_9psock != "" {
+		p := strings.Split(*_9psock, ",")
+		if len(p) != 2 {
+			log.Fatalln("9psock requires two parameters: path,tag")
+		}
+		h.Sockets9P = []hyperkit.Socket9P{{Path: p[0], Tag: p[1]}}
+	}
 
 	if *bg {
 		h.Console = hyperkit.ConsoleFile


### PR DESCRIPTION
Add support for specifying the path and tag of 9p unix domain sockets
that will be exposed to the guest. This is needed to e.g. expose the
vpnkit /ports directory in the guest.

Also adds a nextSlot counter when building the command line so it's
easier to add new parameters that could require multiple PCI slots.

The sample only supports a single 9p socket for now.

Signed-off-by: Magnus Skjegstad <magnus@skjegstad.com>