### PR TITLE
Always return empty VPNKit socket path when input is empty

### DIFF
--- a/go/hyperkit.go
+++ b/go/hyperkit.go
@@ -553,6 +553,9 @@ func checkVPNKitSock(vpnkitsock string) (string, error) {
 	if vpnkitsock == "auto" {
 		vpnkitsock = filepath.Join(getHome(), defaultVPNKitSock)
 	}
+	if vpnkitsock == "" {
+		return "", nil
+	}
 
 	vpnkitsock = filepath.Clean(vpnkitsock)
 	_, err := os.Stat(vpnkitsock)


### PR DESCRIPTION
path.Clean() will set the VPNKit socket path to "." if the input string
is empty. As the HyperKit API uses an empty socket path to disable
networking this made it impossible to disable network support.

The empty socket path is documented in the code here:
https://github.com/moby/hyperkit/blob/master/go/hyperkit.go#L131

Signed-off-by: Magnus Skjegstad <magnus@skjegstad.com>