### PR TITLE
virtio: Fix device ID for the virtio random device

### DIFF
--- a/src/include/xhyve/virtio.h
+++ b/src/include/xhyve/virtio.h
@@ -212,7 +212,7 @@ struct vring_used {
 #define	VIRTIO_VENDOR		0x1AF4
 #define	VIRTIO_DEV_NET		0x1000
 #define	VIRTIO_DEV_BLOCK	0x1001
-#define	VIRTIO_DEV_RANDOM	0x1002
+#define	VIRTIO_DEV_RANDOM	0x1005
 #define VIRTIO_DEV_9P		0x1009
 #define VIRTIO_DEV_SOCK		0x103f /* In the legacy range. */
 


### PR DESCRIPTION
According to the virtio spec[1] the device ID for the virtio
entropy source is 0x1005 and not 0x1002. This fix was already applied
to bhyve[2]. Linux and FreeBSD guests typically match on the
device type and ignore the device ID.

[1] http://docs.oasis-open.org/virtio/virtio/v1.0/cs04/virtio-v1.0-cs04.html#x1-6600011
[2] https://github.com/freebsd/freebsd/commit/919dec09c25924259b40d9f6d09a52ac00bbbba2

Signed-off-by: Rolf Neugebauer <rolf.neugebauer@docker.com>