### PR TITLE
ocaml: update packages to fix CI with OCaml 4.05

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,8 +112,8 @@ OCAML_LDLIBS := -L $(OCAML_WHERE) \
 	$(shell ocamlfind query io-page)/io_page.a \
 	$(shell ocamlfind query io-page-unix)/io_page_unix.a \
 	$(shell ocamlfind query io-page-unix)/libio_page_unix_stubs.a \
-	$(shell ocamlfind query lwt.unix)/liblwt-unix_stubs.a \
-	$(shell ocamlfind query lwt.unix)/lwt-unix.a \
+	$(shell ocamlfind query lwt.unix)/liblwt_unix_stubs.a \
+	$(shell ocamlfind query lwt.unix)/lwt_unix.a \
 	$(shell ocamlfind query lwt.unix)/lwt.a \
 	$(shell ocamlfind query threads)/libthreadsnat.a \
 	$(shell ocamlfind query mirage-block-unix)/libmirage_block_unix_stubs.a \

--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ OCAML_C_SRC := \
 OCAML_WHERE := $(shell ocamlc -where)
 OCAML_PACKS := cstruct cstruct.lwt io-page io-page.unix uri mirage-block \
 	mirage-block-unix qcow unix threads lwt lwt.unix logs logs.fmt   \
-	mirage-unix prometheus-app conduit.lwt cohttp.lwt
+	mirage-unix prometheus-app conduit-lwt cohttp.lwt
 OCAML_LDLIBS := -L $(OCAML_WHERE) \
 	$(shell ocamlfind query cstruct)/cstruct.a \
 	$(shell ocamlfind query cstruct)/libcstruct_stubs.a \

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ via `brew` and using `opam` to install the appropriate libraries:
     $ brew install opam libev
     $ opam init
     $ eval `opam config env`
-    $ opam install uri qcow.0.10.3 qcow-tool mirage-block-unix.2.7.0 conf-libev logs fmt mirage-unix prometheus-app
+    $ opam install uri qcow.0.10.3 conduit.1.0.0 qcow-tool mirage-block-unix.2.7.0 conf-libev logs fmt mirage-unix prometheus-app
 
 Notes:
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ via `brew` and using `opam` to install the appropriate libraries:
     $ brew install opam libev
     $ opam init
     $ eval `opam config env`
-    $ opam install uri qcow.0.10.3 conduit.1.0.0 qcow-tool mirage-block-unix.2.7.0 conf-libev logs fmt mirage-unix prometheus-app
+    $ opam install uri qcow.0.10.3 conduit.1.0.0 lwt.3.1.0 qcow-tool mirage-block-unix.2.7.0 conf-libev logs fmt mirage-unix prometheus-app
 
 Notes:
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ via `brew` and using `opam` to install the appropriate libraries:
     $ brew install opam libev
     $ opam init
     $ eval `opam config env`
-    $ opam install uri qcow.0.10.0 qcow-tool mirage-block-unix.2.7.0 conf-libev logs fmt mirage-unix prometheus-app
+    $ opam install uri qcow.0.10.3 qcow-tool mirage-block-unix.2.7.0 conf-libev logs fmt mirage-unix prometheus-app
 
 Notes:
 

--- a/circle.yml
+++ b/circle.yml
@@ -19,7 +19,7 @@ test:
     - make test
     - brew install opam libev
     - opam init --yes
-    - opam install --yes uri qcow.0.10.0 qcow-tool mirage-block-unix.2.7.0 ocamlfind conf-libev logs fmt mirage-unix prometheus-app
+    - opam install --yes uri qcow.0.10.3 qcow-tool mirage-block-unix.2.7.0 ocamlfind conf-libev logs fmt mirage-unix prometheus-app
     - make clean
     - eval `opam config env` && make all
     - make test

--- a/circle.yml
+++ b/circle.yml
@@ -19,7 +19,7 @@ test:
     - make test
     - brew install opam libev
     - opam init --yes
-    - opam install --yes uri qcow.0.10.3 conduit.1.0.0 qcow-tool mirage-block-unix.2.7.0 ocamlfind conf-libev logs fmt mirage-unix prometheus-app
+    - opam install --yes uri qcow.0.10.3 conduit.1.0.0 lwt.3.1.0 qcow-tool mirage-block-unix.2.7.0 ocamlfind conf-libev logs fmt mirage-unix prometheus-app
     - make clean
     - eval `opam config env` && make all
     - make test

--- a/circle.yml
+++ b/circle.yml
@@ -19,7 +19,7 @@ test:
     - make test
     - brew install opam libev
     - opam init --yes
-    - opam install --yes uri qcow.0.10.3 qcow-tool mirage-block-unix.2.7.0 ocamlfind conf-libev logs fmt mirage-unix prometheus-app
+    - opam install --yes uri qcow.0.10.3 conduit.1.0.0 qcow-tool mirage-block-unix.2.7.0 ocamlfind conf-libev logs fmt mirage-unix prometheus-app
     - make clean
     - eval `opam config env` && make all
     - make test

--- a/circle.yml
+++ b/circle.yml
@@ -11,19 +11,21 @@ machine:
     PROJECT_ROOT: "$GOPATH/src/github.com/moby/hyperkit"
     PATH: "${PATH}:${GOPATH}/bin"
     MACOSX_DEPLOYMENT_TARGET: "10.10"
+    OPAMVERBOSE: "1"
+    OPAMYES: "1"
 test:
   override:
     - make clean
     - make all
     - test ! -s build/lib/mirage_block_ocaml.cmi || (echo "qcow libraries have been pre-installed in CI environment" && exit 1)
     - make test
-    - brew install opam libev
-    - opam init --yes
-    - opam install --yes uri qcow.0.10.3 conduit.1.0.0 lwt.3.1.0 qcow-tool mirage-block-unix.2.7.0 ocamlfind conf-libev logs fmt mirage-unix prometheus-app
-    - make clean
-    - eval `opam config env` && make all
-    - make test
-    - eval `opam config env` && make test-qcow
+    - brew install opam
+    - opam init
+    - opam config exec -- opam depext -i uri qcow.0.10.3 conduit.1.0.0 lwt.3.1.0 qcow-tool mirage-block-unix.2.7.0 ocamlfind conf-libev logs fmt mirage-unix prometheus-app
+    - opam config exec -- make clean
+    - opam config exec -- make all
+    - opam config exec -- make test
+    - opam config exec -- make test-qcow
     # Go related steps
     - mkdir -p $(dirname "$PROJECT_ROOT")
     - ln -s $(pwd) "$PROJECT_ROOT"


### PR DESCRIPTION
`brew` now has OCaml 4.05 which is incompatible with some of the older dependencies. This patch bumps the versions of some of the dependencies and updates the linking step to match.

As a special bonus this removes some libraries which were being linked by accident and shrinks the binary size from:

```
$ ls -l build/hyperkit
-rwxr-xr-x  1 djs  staff  7356796  3 Aug 17:25 build/hyperkit
```
to
```
$ ls -l build/hyperkit
-rwxr-xr-x  1 djs  staff  3965068  3 Aug 17:00 build/hyperkit 
```