### PR TITLE
ocaml: remove `opam config exec` from `opam depext`

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -21,7 +21,7 @@ test:
     - make test
     - brew install opam
     - opam init
-    - opam config exec -- opam depext -i uri qcow.0.10.3 conduit.1.0.0 lwt.3.1.0 qcow-tool mirage-block-unix.2.7.0 ocamlfind conf-libev logs fmt mirage-unix prometheus-app
+    - opam depext -i uri qcow.0.10.3 conduit.1.0.0 lwt.3.1.0 qcow-tool mirage-block-unix.2.7.0 ocamlfind conf-libev logs fmt mirage-unix prometheus-app
     - opam config exec -- make clean
     - opam config exec -- make all
     - opam config exec -- make test


### PR DESCRIPTION
In theory this shouldn't be needed since `opam` should set the environment correctly itself when running `opam-depext` and then `opam install`.

Related to #151

Signed-off-by: David Scott <dave.scott@docker.com>