### PR TITLE
VPNKit protocol and Go API update

### DIFF
--- a/go/sample/main.go
+++ b/go/sample/main.go
@@ -33,6 +33,8 @@ func main() {
 	hk := flag.String("hyperkit", "", "HyperKit binary to use")
 	statedir := flag.String("state", "", "Directory to keep state in")
 	vpnkitsock := flag.String("vpnkitsock", "auto", "Path to VPNKit socket")
+	vpnkituuid := flag.String("vpnkituuid", "", "VPNKit UUID. Allows VMs to reconnect and get the same network configuration.")
+	vpnkitip := flag.String("vpnkitip", "", "Preferred IPv4 address in VPNKit range. Requires an unused UUID.")
 	var disks disks
 	flag.Var(&disks, "disk", "Can be specified multiple times. Format: {file=}PATH{,size=SIZE_IN_MB} or just size=SIZE_IN_MB if -state is set. If PATH doesn't exist and size is specified the image will automatically be created.")
 
@@ -113,6 +115,9 @@ func main() {
 		}
 		h.Sockets9P = []hyperkit.Socket9P{{Path: p[0], Tag: p[1]}}
 	}
+
+	h.VPNKitUUID = *vpnkituuid
+	h.VPNKitPreferredIPv4 = *vpnkitip
 
 	if *bg {
 		h.Console = hyperkit.ConsoleFile


### PR DESCRIPTION
This updates the VPNKit protocol to version 22. This change is incompatible with earlier versions of VPNKit and depends on moby/vpnkit#277.

It was previously possible to encode an IP address in the UUID to request a fixed address from VPNKit. This replaces this functionality with a `preferred_ipv4=` option that can be passed to the driver. IPs encoded in UUIDs are now ignored and treated as a regular UUID.

The new server error messages allows the driver to inform the user about some common VPNKit error conditions, such as if the IP is unavailable. The old driver would just fail with an unspecified vif error.
