### PR TITLE
go: create disks with Truncate

### DIFF
--- a/go/hyperkit.go
+++ b/go/hyperkit.go
@@ -395,11 +395,7 @@ func CreateDiskImage(location string, sizeMB int) error {
 	}
 	defer f.Close()
 
-	buf := make([]byte, 1048676)
-	for i := 0; i < sizeMB; i++ {
-		f.Write(buf)
-	}
-	return nil
+	return f.Truncate(int64(sizeMB) * int64(1024) * int64(1024))
 }
 
 func intArrayToString(i []int, sep string) string {


### PR DESCRIPTION
Previously we made a disk be the correct size by explicitly writing zeroes to it.

This patch uses `Truncate` to make the disk the correct size. If the filesystem supports sparse files (e.g. APFS) then

- it's very fast
- it doesn't actually allocate any space until the VM writes to it

Signed-off-by: David Scott <dave.scott@docker.com>