### PR TITLE
Support TRIM on raw files via F_PUNCHHOLE

### DIFF
--- a/src/lib/pci_ahci.c
+++ b/src/lib/pci_ahci.c
@@ -977,6 +977,7 @@ handle_identify(struct ahci_port *p, int slot, uint8_t *cfis)
 		buf[88] = 0x7f;
 		if (p->xfermode & ATA_UDMA0)
 			buf[88] |= (1 << ((p->xfermode & 7) + 8));
+		buf[93] = (1 | 1 <<14);
 		buf[100] = (uint16_t) sectors;
 		buf[101] = (uint16_t) (sectors >> 16);
 		buf[102] = (uint16_t) (sectors >> 32);

--- a/src/lib/pci_ahci.c
+++ b/src/lib/pci_ahci.c
@@ -797,7 +797,15 @@ next:
 	done += 8;
 	if (elen == 0) {
 		if (done >= len) {
-			ahci_write_fis_d2h(p, slot, cfis, ATA_S_READY | ATA_S_DSC);
+			if (ncq) {
+					if (first)
+							ahci_write_fis_d2h_ncq(p, slot);
+					ahci_write_fis_sdb(p, slot, cfis,
+						ATA_S_READY | ATA_S_DSC);
+			} else {
+					ahci_write_fis_d2h(p, slot, cfis,
+						ATA_S_READY | ATA_S_DSC);
+			}
 			p->pending &= ~(1 << slot);
 			ahci_check_stopped(p);
 			if (!first)
@@ -1726,7 +1734,7 @@ ahci_handle_cmd(struct ahci_port *p, int slot, uint8_t *cfis)
 	case ATA_SEND_FPDMA_QUEUED:
 		if ((cfis[13] & 0x1f) == ATA_SFPDMA_DSM &&
 		    cfis[17] == 0 && cfis[16] == ATA_DSM_TRIM &&
-		    cfis[11] == 0 && cfis[13] == 1) {
+		    cfis[11] == 0 && cfis[3] == 1) {
 			ahci_handle_dsm_trim(p, slot, cfis, 0);
 			break;
 		}


### PR DESCRIPTION
The macOS API `fcntl(F_PUNCHHOLE)` will successfully punch holes in files on APFS and free the backing storage so we can use this to implement the host side of TRIM.

The arguments to the `fcntl` need to be aligned to the filesystems `f_bsize` as returned by `statfs` (which on my Mac's SSD is 4096).

Unfortunately exposing the 4096 byte sectors to the guest seems to trigger a bug elsewhere in the ACHI implementation so this patch maintains a virtual sector size of 512 bytes. This means that the guest will send 512 byte-aligned requests, we must round these to (eg) 4096 byte-aligned requests and manually zero any leading and trailing sectors. For the zeroing we allocate a `delete_zero_buf` per block device and pre-zero it.

When the device is opened we perform a test `F_PUNCHHOLE` of length 0 at offset 0 and check the return value. If the call succeeds then we can assume sparse files is supported (e.g. APFS) and if the call fails we assume sparse files are not supported (e.g. HFS+)

This PR includes 2 patches from bhyve which we were missing. I don't think these are necessary but I thought I'd include them since they exist.