### PR TITLE
Changes for Docker for Mac

### DIFF
--- a/go/disk.go
+++ b/go/disk.go
@@ -1,0 +1,69 @@
+package hyperkit
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// DiskConfig describes a disk image.
+type DiskConfig struct {
+	// Path specifies where the image file will be.
+	Path string `json:"path"`
+	// Size specifies the size of the disk image.  Used if the image needs to be created.
+	Size int `json:"size"`
+	// Format is passed as-is to the driver.
+	Format string `json:"format"`
+	// Driver is the name of the disk driver, "ahci-hd" or "virtio-blk".
+	Driver string `json:"driver"`
+}
+
+// Ensure create the image file if it does not exist.
+func (d *DiskConfig) Ensure() error {
+	if !d.exists() {
+		return d.create()
+	}
+	return nil
+}
+
+// exists if the image file exists.
+func (d *DiskConfig) exists() bool {
+	// FIXME: Temporary workaround.
+	if strings.HasPrefix(d.Path, "file://") {
+		return true
+	}
+	_, err := os.Stat(d.Path)
+	return err == nil
+}
+
+// create creates an empty file suitable for use as a disk image for a hyperkit VM.
+func (d *DiskConfig) create() error {
+	if d.Size == 0 {
+		return fmt.Errorf("Disk image %s not found and unable to create it as size is not specified", d.Path)
+	}
+	diskDir := filepath.Dir(d.Path)
+	if err := os.MkdirAll(diskDir, 0755); err != nil {
+		return err
+	}
+
+	f, err := os.Create(d.Path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	return f.Truncate(int64(d.Size) * int64(1024) * int64(1024))
+}
+
+// AsArgument returns the command-line option to pass after `-s <slot>:0,` to hyperkit for this disk.
+func (d *DiskConfig) AsArgument() string {
+	// Default the driver to virtio-blk.
+	driver := defaultString(d.Driver, "virtio-blk")
+	res := fmt.Sprintf("%s,%s", driver, d.Path)
+	// Add on a format instruction if specified.
+	if d.Format != "" {
+		res += ",format=" + d.Format
+	}
+	return res
+}

--- a/go/doc.go
+++ b/go/doc.go
@@ -12,9 +12,7 @@
 // there.
 //
 // Currently this module has some limitations:
-// - Only supports zero or one disk image
 // - Only support zero or one network interface connected to VPNKit
-// - Only kexec boot
 //
 // This package is currently implemented by shelling out a hyperkit
 // process. In the future we may change this to become a wrapper

--- a/go/doc.go
+++ b/go/doc.go
@@ -1,0 +1,22 @@
+// Package hyperkit provides a Go wrapper around the hyperkit
+// command. It currently shells out to start hyperkit with the
+// provided configuration.
+//
+// Most of the arguments should be self explanatory, but console
+// handling deserves a mention. If the Console is configured with
+// ConsoleStdio, the hyperkit is started with stdin, stdout, and
+// stderr plumbed through to the VM console. If Console is set to
+// ConsoleFile hyperkit the console output is redirected to a file and
+// console input is disabled. For this mode StateDir has to be set and
+// the interactive console is accessible via a 'tty' file created
+// there.
+//
+// Currently this module has some limitations:
+// - Only supports zero or one disk image
+// - Only support zero or one network interface connected to VPNKit
+// - Only kexec boot
+//
+// This package is currently implemented by shelling out a hyperkit
+// process. In the future we may change this to become a wrapper
+// around the hyperkit library.
+package hyperkit

--- a/go/hyperkit.go
+++ b/go/hyperkit.go
@@ -247,7 +247,6 @@ func (h *HyperKit) Start(cmdline string) error {
 }
 
 func (h *HyperKit) execute(cmdline string) error {
-	var err error
 	h.log.Printf("hyperkit: execute %#v", h)
 	// Sanity checks on configuration
 	if h.Console == ConsoleFile && h.StateDir == "" {
@@ -257,7 +256,7 @@ func (h *HyperKit) execute(cmdline string) error {
 		return fmt.Errorf("If ConsoleStdio is set but stdio is not a terminal, StateDir must be specified")
 	}
 	for _, image := range h.ISOImages {
-		if _, err = os.Stat(image); os.IsNotExist(err) {
+		if _, err := os.Stat(image); os.IsNotExist(err) {
 			return fmt.Errorf("ISO %s does not exist", image)
 		}
 	}
@@ -268,14 +267,14 @@ func (h *HyperKit) execute(cmdline string) error {
 		return fmt.Errorf("To forward vsock ports vsock must be enabled")
 	}
 	if h.Bootrom == "" {
-		if _, err = os.Stat(h.Kernel); os.IsNotExist(err) {
+		if _, err := os.Stat(h.Kernel); os.IsNotExist(err) {
 			return fmt.Errorf("Kernel %s does not exist", h.Kernel)
 		}
-		if _, err = os.Stat(h.Initrd); os.IsNotExist(err) {
+		if _, err := os.Stat(h.Initrd); os.IsNotExist(err) {
 			return fmt.Errorf("initrd %s does not exist", h.Initrd)
 		}
 	} else {
-		if _, err = os.Stat(h.Bootrom); os.IsNotExist(err) {
+		if _, err := os.Stat(h.Bootrom); os.IsNotExist(err) {
 			return fmt.Errorf("Bootrom %s does not exist", h.Bootrom)
 		}
 	}
@@ -306,10 +305,9 @@ func (h *HyperKit) execute(cmdline string) error {
 			h.Disks[idx] = config
 		}
 		if !strings.HasPrefix(config.Path, "file://") {
-			if _, err = os.Stat(config.Path); os.IsNotExist(err) {
+			if _, err := os.Stat(config.Path); os.IsNotExist(err) {
 				if config.Size != 0 {
-					err = CreateDiskImage(config.Path, config.Size)
-					if err != nil {
+					if err := CreateDiskImage(config.Path, config.Size); err != nil {
 						return err
 					}
 				} else {

--- a/go/hyperkit.go
+++ b/go/hyperkit.go
@@ -305,14 +305,16 @@ func (h *HyperKit) execute(cmdline string) error {
 			config.Path = filepath.Clean(filepath.Join(h.StateDir, fmt.Sprintf("disk%02d.img", idx)))
 			h.Disks[idx] = config
 		}
-		if _, err = os.Stat(config.Path); os.IsNotExist(err) {
-			if config.Size != 0 {
-				err = CreateDiskImage(config.Path, config.Size)
-				if err != nil {
-					return err
+		if !strings.HasPrefix(config.Path, "file://") {
+			if _, err = os.Stat(config.Path); os.IsNotExist(err) {
+				if config.Size != 0 {
+					err = CreateDiskImage(config.Path, config.Size)
+					if err != nil {
+						return err
+					}
+				} else {
+					return fmt.Errorf("Disk image %s not found and unable to create it as size is not specified", config.Path)
 				}
-			} else {
-				return fmt.Errorf("Disk image %s not found and unable to create it as size is not specified", config.Path)
 			}
 		}
 	}

--- a/go/hyperkit.go
+++ b/go/hyperkit.go
@@ -47,13 +47,6 @@ type Socket9P struct {
 	Tag  string `json:"tag"`
 }
 
-// Logger is an interface for logging.
-type Logger interface {
-	Fatalf(format string, v ...interface{})
-	Panicf(format string, v ...interface{})
-	Printf(format string, v ...interface{})
-}
-
 // HyperKit contains the configuration of the hyperkit VM
 type HyperKit struct {
 	// HyperKit is the path to the hyperkit binary.
@@ -131,9 +124,6 @@ type HyperKit struct {
 
 	process    *os.Process
 	background bool
-
-	// log receives stdout/stderr of the hyperkit process itself, if set.
-	log Logger
 }
 
 // New creates a template config structure.
@@ -200,8 +190,8 @@ func FromState(statedir string) (*HyperKit, error) {
 
 // SetLogger sets the log instance to use for the output of the hyperkit process itself (not the console of the VM).
 // This is only relevant when Console is set to ConsoleFile
-func (h *HyperKit) SetLogger(logger Logger) {
-	h.log = logger
+func (h *HyperKit) SetLogger(l Logger) {
+	SetLogger(l)
 }
 
 // Run the VM with a given command line until it exits
@@ -217,7 +207,7 @@ func (h *HyperKit) Start(cmdline string) error {
 }
 
 func (h *HyperKit) execute(cmdline string) error {
-	h.log.Printf("hyperkit: execute %#v", h)
+	log.Debugf("hyperkit: execute %#v", h)
 	// Sanity checks on configuration
 	if h.Console == ConsoleFile && h.StateDir == "" {
 		return fmt.Errorf("If ConsoleFile is set, StateDir must be specified")
@@ -443,8 +433,8 @@ func (h *HyperKit) buildArgs(cmdline string) {
 
 	h.Arguments = a
 	h.CmdLine = h.HyperKit + " " + strings.Join(a, " ")
-	h.log.Printf("hyperkit: Arguments: %#v", h.Arguments)
-	h.log.Printf("hyperkit: CmdLine: %#v", h.CmdLine)
+	log.Debugf("hyperkit: Arguments: %#v", h.Arguments)
+	log.Debugf("hyperkit: CmdLine: %#v", h.CmdLine)
 }
 
 // Execute hyperkit and plumb stdin/stdout/stderr.
@@ -492,8 +482,8 @@ func (h *HyperKit) execHyperKit() error {
 				tty.Close()
 			}()
 		}
-	} else if h.log != nil {
-		h.log.Printf("hyperkit: Redirecting stdout/stderr to logger")
+	} else if log != nil {
+		log.Debugf("hyperkit: Redirecting stdout/stderr to logger")
 		stdoutChan := make(chan string)
 		stderrChan := make(chan string)
 		stdout, err := cmd.StdoutPipe()
@@ -512,9 +502,9 @@ func (h *HyperKit) execHyperKit() error {
 			for {
 				select {
 				case stderrl := <-stderrChan:
-					h.log.Printf("%s", stderrl)
+					log.Infof("%s", stderrl)
 				case stdoutl := <-stdoutChan:
-					h.log.Printf("%s", stdoutl)
+					log.Infof("%s", stdoutl)
 				case <-done:
 					return
 				}
@@ -522,22 +512,22 @@ func (h *HyperKit) execHyperKit() error {
 		}()
 	}
 
-	h.log.Printf("hyperkit: Starting %#v", cmd)
+	log.Debugf("hyperkit: Starting %#v", cmd)
 	err := cmd.Start()
 	if err != nil {
 		return err
 	}
 	h.Pid = cmd.Process.Pid
-	h.log.Printf("hyperkit: Pid is %v", h.Pid)
+	log.Debugf("hyperkit: Pid is %v", h.Pid)
 	h.process = cmd.Process
 	err = h.writeState()
 	if err != nil {
-		h.log.Printf("hyperkit: Cannot write state: %v, killing %v", err, h.Pid)
+		log.Debugf("hyperkit: Cannot write state: %v, killing %v", err, h.Pid)
 		h.process.Kill()
 		return err
 	}
 	if !h.background {
-		h.log.Printf("hyperkit: Waiting for %#v", cmd)
+		log.Debugf("hyperkit: Waiting for %#v", cmd)
 		err = cmd.Wait()
 		if err != nil {
 			return err
@@ -545,7 +535,7 @@ func (h *HyperKit) execHyperKit() error {
 	} else {
 		// Make sure we reap the child when it exits
 		go func() {
-			h.log.Printf("hyperkit: Waiting for %#v", cmd)
+			log.Debugf("hyperkit: Waiting for %#v", cmd)
 			cmd.Wait()
 		}()
 	}

--- a/go/hyperkit.go
+++ b/go/hyperkit.go
@@ -41,9 +41,9 @@ import (
 )
 
 const (
-	// ConsoleStdio configures console to use Stdio
+	// ConsoleStdio configures console to use Stdio.
 	ConsoleStdio = iota
-	// ConsoleFile configures console to a tty and output to a file
+	// ConsoleFile configures console to a tty and output to a file.
 	ConsoleFile
 
 	defaultVPNKitSock = "Library/Containers/com.docker.docker/Data/s50"
@@ -69,11 +69,15 @@ type Socket9P struct {
 	Tag  string `json:"tag"`
 }
 
-// DiskConfig contains the path to a disk image and an optional size if the image needs to be created.
+// DiskConfig describes a disk image.
 type DiskConfig struct {
-	Path   string `json:"path"`
-	Size   int    `json:"size"`
+	// Path specifies where the image file will be.
+	Path string `json:"path"`
+	// Size specifies the size of the disk image.  Used if the image needs to be created.
+	Size int `json:"size"`
+	// Format is passed as-is to the driver.
 	Format string `json:"format"`
+	// Driver is the name of the disk driver, "ahci-hd" or "virtio-blk".
 	Driver string `json:"driver"`
 }
 

--- a/go/hyperkit.go
+++ b/go/hyperkit.go
@@ -319,12 +319,7 @@ func (h *HyperKit) execute(cmdline string) error {
 
 	// Run
 	h.buildArgs(cmdline)
-	err = h.execHyperKit()
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return h.execHyperKit()
 }
 
 // Stop the running VM
@@ -335,12 +330,7 @@ func (h *HyperKit) Stop() error {
 	if !h.IsRunning() {
 		return nil
 	}
-	err := h.process.Kill()
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return h.process.Kill()
 }
 
 // IsRunning returns true if the hyperkit process is running.
@@ -350,13 +340,7 @@ func (h *HyperKit) IsRunning() bool {
 	// a call to find out if the process is running either, so we
 	// use another package to find out.
 	proc, err := ps.FindProcess(h.Pid)
-	if err != nil {
-		return false
-	}
-	if proc == nil {
-		return false
-	}
-	return true
+	return err == nil && proc != nil
 }
 
 // isDisk checks if the specified path is used as a disk image
@@ -397,7 +381,7 @@ func (h *HyperKit) Remove(keepDisk bool) error {
 	return nil
 }
 
-// Convert to json string
+// Convert to json string.
 func (h *HyperKit) String() string {
 	s, err := json.Marshal(h)
 	if err != nil {

--- a/go/hyperkit.go
+++ b/go/hyperkit.go
@@ -297,25 +297,25 @@ func (h *HyperKit) execute(cmdline string) error {
 		}
 	}
 
-	for idx, config := range h.Disks {
-		if config.Path == "" {
+	for idx, disk := range h.Disks {
+		if disk.Path == "" {
 			if h.StateDir == "" {
 				return fmt.Errorf("Unable to create disk image when neither path nor state dir is set")
 			}
-			if config.Size <= 0 {
+			if disk.Size <= 0 {
 				return fmt.Errorf("Unable to create disk image when size is 0 or not set")
 			}
-			config.Path = filepath.Clean(filepath.Join(h.StateDir, fmt.Sprintf("disk%02d.img", idx)))
-			h.Disks[idx] = config
+			disk.Path = filepath.Clean(filepath.Join(h.StateDir, fmt.Sprintf("disk%02d.img", idx)))
+			h.Disks[idx] = disk
 		}
-		if !strings.HasPrefix(config.Path, "file://") {
-			if _, err := os.Stat(config.Path); os.IsNotExist(err) {
-				if config.Size != 0 {
-					if err := CreateDiskImage(config.Path, config.Size); err != nil {
+		if !strings.HasPrefix(disk.Path, "file://") {
+			if _, err := os.Stat(disk.Path); os.IsNotExist(err) {
+				if disk.Size != 0 {
+					if err := CreateDiskImage(disk.Path, disk.Size); err != nil {
 						return err
 					}
 				} else {
-					return fmt.Errorf("Disk image %s not found and unable to create it as size is not specified", config.Path)
+					return fmt.Errorf("Disk image %s not found and unable to create it as size is not specified", disk.Path)
 				}
 			}
 		}
@@ -349,8 +349,8 @@ func (h *HyperKit) IsRunning() bool {
 
 // isDisk checks if the specified path is used as a disk image
 func (h *HyperKit) isDisk(path string) bool {
-	for _, config := range h.Disks {
-		if filepath.Clean(path) == filepath.Clean(config.Path) {
+	for _, disk := range h.Disks {
+		if filepath.Clean(path) == filepath.Clean(disk.Path) {
 			return true
 		}
 	}

--- a/go/log.go
+++ b/go/log.go
@@ -1,0 +1,42 @@
+package hyperkit
+
+import (
+	golog "log"
+)
+
+// Logger is an interface for logging.
+type Logger interface {
+	// Debugf logs a message with "debug" severity (very verbose).
+	Debugf(format string, v ...interface{})
+	// Infof logs a message with "info" severity (less verbose).
+	Infof(format string, v ...interface{})
+	// Fatalf logs a fatal error message, and exits 1.
+	Fatalf(format string, v ...interface{})
+}
+
+// StandardLogger makes the go standard logger comply to our Logger interface.
+type StandardLogger struct{}
+
+// Debugf logs a message with "debug" severity.
+func (*StandardLogger) Debugf(f string, v ...interface{}) {
+	golog.Printf(f, v...)
+}
+
+// Infof logs a message with "info" severity.
+func (*StandardLogger) Infof(f string, v ...interface{}) {
+	golog.Printf(f, v...)
+}
+
+// Fatalf logs a fatal error message, and exits 1.
+func (*StandardLogger) Fatalf(f string, v ...interface{}) {
+	golog.Fatalf(f, v...)
+}
+
+// Log receives stdout/stderr of the hyperkit process itself, if set.
+// It defaults to the go standard logger.
+var log Logger = &StandardLogger{}
+
+// SetLogger sets the logger to use.
+func SetLogger(l Logger) {
+	log = l
+}

--- a/go/pty_util_fallback.go
+++ b/go/pty_util_fallback.go
@@ -3,22 +3,21 @@
 package hyperkit
 
 import (
-	"log"
 	"os"
 )
 
 func saneTerminal(f *os.File) error {
-	log.Fatal("Function not supported on your OS")
+	log.Fatalf("Function not supported on your OS")
 	return nil
 }
 
 func setRaw(f *os.File) error {
-	log.Fatal("Function not supported on your OS")
+	log.Fatalf("Function not supported on your OS")
 	return nil
 }
 
 // isTerminal checks if the provided file is a terminal
 func isTerminal(f *os.File) bool {
-	log.Fatal("Function not supported on your OS")
+	log.Fatalf("Function not supported on your OS")
 	return false
 }


### PR DESCRIPTION
Currently there is some overlap between what hyperkit and piñata do, especially wrt the management of disk images.  Piñata can build raw images, and so does hyperkit.  Currently the code is duplicated, and Piñata will be adapted to use hyperkit on this area.

However Piñata also support qcow images, which requires `qcow-tool`, which is a dependency that I don't think hyperkit wants.  So the plan is to introduce an interface for disks in hyperkit, move the current support for raw images to comply with it, and then to introduce support for qcow images in Piñata, via this interface.

This is the plan.  This series of patches is meant to checkpoint: let's first have these first steps validated, then I'll proceed on both sides.
