### PR TITLE
Fix repo references in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-## [HyperKit](http://github.com/docker/hyperkit)
+## [HyperKit](http://github.com/moby/hyperkit)
 
-![Build Status OSX](https://circleci.com/gh/docker/hyperkit.svg?style=shield&circle-token=cf8379b302eab2bbf33821cafe164dbefb71982d)
+![Build Status OSX](https://circleci.com/gh/moby/hyperkit.svg?style=shield&circle-token=cf8379b302eab2bbf33821cafe164dbefb71982d)
 
-*HyperKit* is a toolkit for embedding hypervisor capabilities in your application. It includes a complete hypervisor, based on [xhyve](https://github.com/mist64/xhyve)/[bhyve](http://bhyve.org), which is optimized for lightweight virtual machines and container deployment.  It is designed to be interfaced with higher-level components such as the [VPNKit](https://github.com/docker/vpnkit) and [DataKit](https://github.com/docker/datakit).
+*HyperKit* is a toolkit for embedding hypervisor capabilities in your application. It includes a complete hypervisor, based on [xhyve](https://github.com/mist64/xhyve)/[bhyve](http://bhyve.org), which is optimized for lightweight virtual machines and container deployment.  It is designed to be interfaced with higher-level components such as the [VPNKit](https://github.com/moby/vpnkit) and [DataKit](https://github.com/moby/datakit).
 
 HyperKit currently only supports Mac OS X using the [Hypervisor.framework](https://developer.apple.com/library/mac/documentation/DriversKernelHardware/Reference/Hypervisor/index.html). It is a core component of Docker For Mac.
 
@@ -24,7 +24,7 @@ If you are using Hyperkit directly then please report issues against this reposi
 
 ## Building
 
-    $ git clone https://github.com/docker/hyperkit
+    $ git clone https://github.com/moby/hyperkit
     $ cd hyperkit
     $ make
 


### PR DESCRIPTION
Initially, I only wanted to see build badge, but then I also fixed the links for {vpn,data}kit.