### PR TITLE
Changes for Docker for Mac

### DIFF
--- a/go/Makefile
+++ b/go/Makefile
@@ -30,6 +30,7 @@ build/hyperkitgo.exe: $(DEPS)
 	go build -o $@ --ldflags '-extldflags "-fno-PIC"' \
 		sample/main.go
 
+.PHONY: clean fmt lint check
 clean:
 	rm -rf build
 
@@ -42,6 +43,10 @@ lint:
 	$(if $(shell which golint || echo ''), , \
 		$(error Please install golint))
 	@test -z "$$(golint ./... 2>&1 | grep -v ^vendor/ | grep -v mock/ | tee /dev/stderr)"
+
+check:
+	@echo "+ $@"
+	@go test . $(TESTFLAGS)
 
 # this will blow away the vendored code and update it to latest
 .PHONY: vendor vendor-local

--- a/go/Makefile
+++ b/go/Makefile
@@ -30,7 +30,7 @@ build/hyperkitgo.exe: $(DEPS)
 	go build -o $@ --ldflags '-extldflags "-fno-PIC"' \
 		sample/main.go
 
-.PHONY: clean fmt lint check
+.PHONY: clean fmt lint test
 clean:
 	rm -rf build
 
@@ -44,9 +44,13 @@ lint:
 		$(error Please install golint))
 	@test -z "$$(golint ./... 2>&1 | grep -v ^vendor/ | grep -v mock/ | tee /dev/stderr)"
 
-check:
+test:
 	@echo "+ $@"
-	@go test . $(TESTFLAGS)
+# We pass the module path (not just `.`) because in the CI we play
+# tricks with symlinks that confuse go test: when we enter `go/`, we
+# are no longer in the go tree, but back in ~/distiller/hyperkit/go
+# where Circle CI forces our checkout.
+	@go test -v $(TESTFLAGS) github.com/moby/hyperkit/go
 
 # this will blow away the vendored code and update it to latest
 .PHONY: vendor vendor-local
@@ -67,6 +71,6 @@ vendor-local:
 setup:
 	go get github.com/golang/lint/golint
 
-ci: setup build/hyperkitgo build/hyperkitgo_linux build/hyperkitgo.exe
+ci: setup build/hyperkitgo build/hyperkitgo_linux build/hyperkitgo.exe test
 	test -z "$$(gofmt -s -l . 2>&1 | grep -v ^vendor/ | tee /dev/stderr)"
 	test -z "$$(golint ./... 2>&1 | grep -v ^vendor/ | grep -v mock/ | tee /dev/stderr)"

--- a/go/disk.go
+++ b/go/disk.go
@@ -233,8 +233,11 @@ func (d *QcowDisk) String() string {
 
 // QcowTool prepares a call to qcow-tool on this image.
 func (d *QcowDisk) QcowTool(verb string, args ...string) *exec.Cmd {
-	return exec.Command(defaultString(d.QcowToolPath, "qcow-tool"),
-		append([]string{verb, d.Path}, args...)...)
+	path := d.QcowToolPath
+	if path == "" {
+		path = "qcow-tool"
+	}
+	return exec.Command(path, append([]string{verb, d.Path}, args...)...)
 }
 
 // Exists if the image file exists.
@@ -333,7 +336,13 @@ func (d *QcowDisk) Stop(lockFile *os.File) error {
 // AsArgument returns the command-line option to pass after `-s <slot>:0,` to hyperkit for this disk.
 func (d *QcowDisk) AsArgument() string {
 	res := fmt.Sprintf("%s,file://%s?sync=%s&buffered=1", diskDriver(d.Trim), d.Path, d.OnFlush)
-	res += fmt.Sprintf(",format=%v", defaultString(d.Format, "qcow"))
+	{
+		format := d.Format
+		if format == "" {
+			format = "qcow"
+		}
+		res += fmt.Sprintf(",format=%v", format)
+	}
 	if d.Stats != "" {
 		res += ",qcow-stats-config=" + d.Stats
 	}

--- a/go/disk.go
+++ b/go/disk.go
@@ -3,10 +3,106 @@ package hyperkit
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 )
 
-// RawDisk describes a disk image.
+const (
+	mib = int64(1024 * 1024)
+)
+
+/*-------.
+| Disk.  |
+`-------*/
+
+// Disk in an interface for qcow2 and raw disk images.
+type Disk interface {
+	// GetPath returns the location of the disk image file.
+	GetPath() string
+	// SetPath changes the location of the disk image file.
+	SetPath(p string)
+	// GetSize returns the desired size of the disk image file.
+	GetSize() int
+	// String returns the path.
+	String() string
+
+	// Exists is true iff the disk image file exists.
+	Exists() bool
+	// Ensure creates the disk image if needed, and resizes it if needed.
+	Ensure() error
+	// Stop can be called when hyperkit has quit.  It performs sanity checks, compaction, etc.
+	// It can be passed a lock file which is not-used, but kept alive even if the parent
+	// process died.
+	Stop(lockFile *os.File) error
+
+	// AsArgument returns the command-line option to pass after `-s <slot>:0,` to hyperkit for this disk.
+	AsArgument() string
+
+	create() error
+	getFileSize() (int, error)
+	resize() error
+}
+
+// exists if the image file exists.
+func exists(d Disk) bool {
+	_, err := os.Stat(d.GetPath())
+	return err == nil
+}
+
+// ensure creates the disk image if needed, and resizes it if needed.
+func ensure(d Disk) error {
+	current, err := d.getFileSize()
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return err
+		}
+		return d.create()
+	}
+	if current < d.GetSize() {
+		log.Infof("Attempting to resize %q from %dMiB to %dMiB", d, current, d.GetSize())
+		return d.resize()
+	}
+	if d.GetSize() < current {
+		log.Errorf("Cannot safely shrink %q from %dMiB to %dMiB", d, current, d.GetSize())
+	}
+	return nil
+}
+
+// diskDriver to use.
+//
+// Dave Scott writes:
+//
+// > Regarding TRIM and raw disks
+// > (https://github.com/docker/pinata/pull/8235/commits/0e2c7c2e21114b4ed61589bd42b720f7d88c0d8e):
+// > it works like this: the `ahci-hd` virtual hardware in hyperkit
+// > exposes the `ATA_SUPPORT_DSM_TRIM` capability
+// > (https://github.com/moby/hyperkit/blob/81fa6279fcb17e8435f3cec0978e9aa3af02e63b/src/lib/pci_ahci.c#L996)
+// > if the `fcntl(F_PUNCHHOLE)`
+// > (https://github.com/moby/hyperkit/blob/81fa6279fcb17e8435f3cec0978e9aa3af02e63b/src/lib/block_if.c#L276)
+// > API works on the raw file (it's dynamically detected so on HFS+ it's
+// > disabled and on APFS it's enabled) -> TRIM on raw doesn't need any
+// > special flags set in the Go code; the special flags are only for the
+// > TRIM on qcow implementation. When images are deleted in the VM the
+// > `trim-after-delete`
+// > (https://github.com/linuxkit/linuxkit/tree/master/pkg/trim-after-delete)
+// > daemon calls `fstrim /var/lib/docker` which causes Linux to emit the
+// > TRIM commands to hyperkit, which calls `fcntl`, which tells macOS to
+// > free the space in the file, visible in `ls -sl`.
+// >
+// > Unfortunately the `virtio-blk` protocol doesn't support `TRIM`
+// > requests at all so we have to use `ahci-hd` (if you try to run
+// > `fstrim /var/lib/docker` with `virtio-blk` it'll give an `ioctl`
+// > error).
+func diskDriver(trim bool) string {
+	if trim {
+		return "ahci-hd"
+	}
+	return "virtio-blk"
+}
+
+/*----------.
+| RawDisk.  |
+`----------*/
+
+// RawDisk describes a raw disk image file.
 type RawDisk struct {
 	// Path specifies where the image file will be.
 	Path string `json:"path"`
@@ -14,8 +110,8 @@ type RawDisk struct {
 	Size int `json:"size"`
 	// Format is passed as-is to the driver.
 	Format string `json:"format"`
-	// Driver is the name of the disk driver, "ahci-hd" or "virtio-blk".
-	Driver string `json:"driver"`
+	// Trim specifies whether we should trim the image file.
+	Trim bool `json:"trim"`
 }
 
 // GetPath returns the location of the disk image file.
@@ -38,42 +134,49 @@ func (d *RawDisk) String() string {
 	return d.Path
 }
 
-// Ensure create the image file if it does not exist.
+// Exists if the image file exists.
+func (d *RawDisk) Exists() bool {
+	return exists(d)
+}
+
+// Ensure creates the disk image if needed, and resizes it if needed.
 func (d *RawDisk) Ensure() error {
-	if !d.exists() {
-		return d.create()
-	}
-	return nil
+	return ensure(d)
 }
 
-// exists if the image file exists.
-func (d *RawDisk) exists() bool {
-	_, err := os.Stat(d.Path)
-	return err == nil
-}
-
-// create creates an empty file suitable for use as a disk image for a hyperkit VM.
+// Create a disk.
 func (d *RawDisk) create() error {
-	if d.Size == 0 {
-		return fmt.Errorf("Disk image %s not found and unable to create it as size is not specified", d.Path)
-	}
-	diskDir := filepath.Dir(d.Path)
-	if err := os.MkdirAll(diskDir, 0755); err != nil {
-		return err
-	}
-
 	f, err := os.Create(d.Path)
 	if err != nil {
 		return err
 	}
 	defer f.Close()
+	return f.Truncate(int64(d.Size) * mib)
+}
 
-	return f.Truncate(int64(d.Size) * int64(1024) * int64(1024))
+// Query the current virtual size of the disk in MiB
+func (d *RawDisk) getFileSize() (int, error) {
+	// Return a failure if the file doesn't exist yet
+	fileinfo, err := os.Stat(d.Path)
+	if err != nil {
+		return 0, err
+	}
+	return int(fileinfo.Size() / mib), nil
+}
+
+// Resize the virtual size of the disk
+func (d *RawDisk) resize() error {
+	return os.Truncate(d.Path, int64(d.Size)*mib)
+}
+
+// Stop cleans up this disk when we are quitting.
+func (d *RawDisk) Stop(lockFile *os.File) error {
+	return nil
 }
 
 // AsArgument returns the command-line option to pass after `-s <slot>:0,` to hyperkit for this disk.
 func (d *RawDisk) AsArgument() string {
-	res := fmt.Sprintf("%s,%s", defaultString(d.Driver, "virtio-blk"), d.Path)
+	res := fmt.Sprintf("%s,%s", diskDriver(d.Trim), d.Path)
 	if d.Format != "" {
 		res += ",format=" + d.Format
 	}

--- a/go/disk.go
+++ b/go/disk.go
@@ -6,8 +6,8 @@ import (
 	"path/filepath"
 )
 
-// DiskConfig describes a disk image.
-type DiskConfig struct {
+// RawDisk describes a disk image.
+type RawDisk struct {
 	// Path specifies where the image file will be.
 	Path string `json:"path"`
 	// Size specifies the size of the disk image.  Used if the image needs to be created.
@@ -18,28 +18,28 @@ type DiskConfig struct {
 	Driver string `json:"driver"`
 }
 
-// GetPath is the location of the disk image file.
-func (d *DiskConfig) GetPath() string {
+// GetPath returns the location of the disk image file.
+func (d *RawDisk) GetPath() string {
 	return d.Path
 }
 
 // SetPath changes the location of the disk image file.
-func (d *DiskConfig) SetPath(p string) {
+func (d *RawDisk) SetPath(p string) {
 	d.Path = p
 }
 
-// GetSize is the desired size of the disk image file.
-func (d *DiskConfig) GetSize() int {
+// GetSize returns the desired size of the disk image file.
+func (d *RawDisk) GetSize() int {
 	return d.Size
 }
 
 // String returns the path.
-func (d *DiskConfig) String() string {
+func (d *RawDisk) String() string {
 	return d.Path
 }
 
 // Ensure create the image file if it does not exist.
-func (d *DiskConfig) Ensure() error {
+func (d *RawDisk) Ensure() error {
 	if !d.exists() {
 		return d.create()
 	}
@@ -47,13 +47,13 @@ func (d *DiskConfig) Ensure() error {
 }
 
 // exists if the image file exists.
-func (d *DiskConfig) exists() bool {
+func (d *RawDisk) exists() bool {
 	_, err := os.Stat(d.Path)
 	return err == nil
 }
 
 // create creates an empty file suitable for use as a disk image for a hyperkit VM.
-func (d *DiskConfig) create() error {
+func (d *RawDisk) create() error {
 	if d.Size == 0 {
 		return fmt.Errorf("Disk image %s not found and unable to create it as size is not specified", d.Path)
 	}
@@ -72,7 +72,7 @@ func (d *DiskConfig) create() error {
 }
 
 // AsArgument returns the command-line option to pass after `-s <slot>:0,` to hyperkit for this disk.
-func (d *DiskConfig) AsArgument() string {
+func (d *RawDisk) AsArgument() string {
 	res := fmt.Sprintf("%s,%s", defaultString(d.Driver, "virtio-blk"), d.Path)
 	if d.Format != "" {
 		res += ",format=" + d.Format

--- a/go/disk.go
+++ b/go/disk.go
@@ -1,0 +1,81 @@
+package hyperkit
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// DiskConfig describes a disk image.
+type DiskConfig struct {
+	// Path specifies where the image file will be.
+	Path string `json:"path"`
+	// Size specifies the size of the disk image.  Used if the image needs to be created.
+	Size int `json:"size"`
+	// Format is passed as-is to the driver.
+	Format string `json:"format"`
+	// Driver is the name of the disk driver, "ahci-hd" or "virtio-blk".
+	Driver string `json:"driver"`
+}
+
+// GetPath is the location of the disk image file.
+func (d *DiskConfig) GetPath() string {
+	return d.Path
+}
+
+// SetPath changes the location of the disk image file.
+func (d *DiskConfig) SetPath(p string) {
+	d.Path = p
+}
+
+// GetSize is the desired size of the disk image file.
+func (d *DiskConfig) GetSize() int {
+	return d.Size
+}
+
+// String returns the path.
+func (d *DiskConfig) String() string {
+	return d.Path
+}
+
+// Ensure create the image file if it does not exist.
+func (d *DiskConfig) Ensure() error {
+	if !d.exists() {
+		return d.create()
+	}
+	return nil
+}
+
+// exists if the image file exists.
+func (d *DiskConfig) exists() bool {
+	_, err := os.Stat(d.Path)
+	return err == nil
+}
+
+// create creates an empty file suitable for use as a disk image for a hyperkit VM.
+func (d *DiskConfig) create() error {
+	if d.Size == 0 {
+		return fmt.Errorf("Disk image %s not found and unable to create it as size is not specified", d.Path)
+	}
+	diskDir := filepath.Dir(d.Path)
+	if err := os.MkdirAll(diskDir, 0755); err != nil {
+		return err
+	}
+
+	f, err := os.Create(d.Path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	return f.Truncate(int64(d.Size) * int64(1024) * int64(1024))
+}
+
+// AsArgument returns the command-line option to pass after `-s <slot>:0,` to hyperkit for this disk.
+func (d *DiskConfig) AsArgument() string {
+	res := fmt.Sprintf("%s,%s", defaultString(d.Driver, "virtio-blk"), d.Path)
+	if d.Format != "" {
+		res += ",format=" + d.Format
+	}
+	return res
+}

--- a/go/disk.go
+++ b/go/disk.go
@@ -23,7 +23,7 @@ type Disk interface {
 	GetPath() string
 	// SetPath changes the location of the disk image file.
 	SetPath(p string)
-	// GetSize returns the desired size of the disk image file.
+	// GetSize returns the desired disk size.
 	GetSize() int
 	// String returns the path.
 	String() string
@@ -41,8 +41,8 @@ type Disk interface {
 	AsArgument() string
 
 	create() error
-	// Query the current virtual size of the disk in MiB.
-	getFileSize() (int, error)
+	// The current disk size in MiB.
+	getCurrentSize() (int, error)
 	resize() error
 }
 
@@ -57,7 +57,7 @@ func exists(d Disk) bool {
 
 // ensure creates the disk image if needed, and resizes it if needed.
 func ensure(d Disk) error {
-	current, err := d.getFileSize()
+	current, err := d.getCurrentSize()
 	if err != nil {
 		if !os.IsNotExist(err) {
 			return err
@@ -114,7 +114,7 @@ func diskDriver(trim bool) string {
 type RawDisk struct {
 	// Path specifies where the image file will be.
 	Path string `json:"path"`
-	// Size specifies the size of the disk image.  Used if the image needs to be created.
+	// Size specifies the size of the disk.
 	Size int `json:"size"`
 	// Format is passed as-is to the driver.
 	Format string `json:"format"`
@@ -132,7 +132,7 @@ func (d *RawDisk) SetPath(p string) {
 	d.Path = p
 }
 
-// GetSize returns the desired size of the disk image file.
+// GetSize returns the desired disk size.
 func (d *RawDisk) GetSize() int {
 	return d.Size
 }
@@ -162,8 +162,8 @@ func (d *RawDisk) create() error {
 	return f.Truncate(int64(d.Size) * mib)
 }
 
-// Query the current virtual size of the disk in MiB
-func (d *RawDisk) getFileSize() (int, error) {
+// The current disk size in MiB.
+func (d *RawDisk) getCurrentSize() (int, error) {
 	fileinfo, err := os.Stat(d.Path)
 	if err != nil {
 		return 0, err
@@ -198,7 +198,7 @@ func (d *RawDisk) AsArgument() string {
 type QcowDisk struct {
 	// Path specifies where the image file will be.
 	Path string `json:"path"`
-	// Size specifies the size of the disk image.  Used if the image needs to be created.
+	// Size specifies the size of the disk.
 	Size int `json:"size"`
 	// Format is passed as-is to the driver.
 	Format string `json:"format"`
@@ -224,7 +224,7 @@ func (d *QcowDisk) SetPath(p string) {
 	d.Path = p
 }
 
-// GetSize returns the desired size of the disk image file.
+// GetSize returns the desired disk size.
 func (d *QcowDisk) GetSize() int {
 	return d.Size
 }
@@ -262,8 +262,8 @@ func (d *QcowDisk) create() error {
 	return cmd.Wait()
 }
 
-// Query the current virtual size of the disk in MiB
-func (d *QcowDisk) getFileSize() (int, error) {
+// The current disk size in MiB.
+func (d *QcowDisk) getCurrentSize() (int, error) {
 	if _, err := os.Stat(d.Path); err != nil {
 		return 0, err
 	}
@@ -283,7 +283,7 @@ func (d *QcowDisk) resize() error {
 }
 
 func (d *QcowDisk) sizeString() string {
-	s, err := d.getFileSize()
+	s, err := d.getCurrentSize()
 	if err != nil {
 		return fmt.Sprintf("cannot get size: %v", err)
 	}

--- a/go/disk.go
+++ b/go/disk.go
@@ -236,11 +236,10 @@ func (d *QcowDisk) String() string {
 
 // QcowTool prepares a call to qcow-tool on this image.
 func (d *QcowDisk) QcowTool(verb string, args ...string) *exec.Cmd {
-	path := d.QcowToolPath
-	if path == "" {
-		path = "qcow-tool"
+	if d.QcowToolPath == "" {
+		d.QcowToolPath = "qcow-tool"
 	}
-	return exec.Command(path, append([]string{verb, d.Path}, args...)...)
+	return exec.Command(d.QcowToolPath, append([]string{verb, d.Path}, args...)...)
 }
 
 func run(cmd *exec.Cmd) (string, error) {

--- a/go/disk_test.go
+++ b/go/disk_test.go
@@ -1,0 +1,49 @@
+package hyperkit
+
+import (
+	"os"
+	"reflect"
+	"testing"
+)
+
+// checkEqual allows to avoid importing testify.
+func checkEqual(t *testing.T, expected, effective interface{}) {
+	if !reflect.DeepEqual(expected, effective) {
+		t.Errorf("FAIL:\n expected: %v\neffective: %v", expected, effective)
+	}
+}
+
+func TestRawDisk(t *testing.T) {
+	disk := RawDisk{
+		Path: "test.raw",
+		Size: 1,
+	}
+	os.Remove(disk.Path)
+
+	checkEqual(t, "virtio-blk,test.raw", disk.AsArgument())
+	checkEqual(t, nil, disk.Ensure())
+	// Running twice is fine.
+	checkEqual(t, nil, disk.Ensure())
+	{
+		s, err := os.Stat(disk.Path)
+		checkEqual(t, nil, err)
+		checkEqual(t, 1024*1024, int(s.Size()))
+	}
+	// Rerunning resizes.
+	disk.Size = 2
+	checkEqual(t, nil, disk.Ensure())
+	{
+		s, err := os.Stat(disk.Path)
+		checkEqual(t, nil, err)
+		checkEqual(t, 2*1024*1024, int(s.Size()))
+	}
+}
+
+func TestRawDiskTrim(t *testing.T) {
+	disk := RawDisk{
+		Path: "test.raw",
+		Size: 1,
+		Trim: true,
+	}
+	checkEqual(t, "ahci-hd,test.raw", disk.AsArgument())
+}

--- a/go/disk_test.go
+++ b/go/disk_test.go
@@ -10,7 +10,7 @@ import (
 // checkEqual allows to avoid importing testify.
 func checkEqual(t *testing.T, expected, effective interface{}) {
 	if !reflect.DeepEqual(expected, effective) {
-		t.Errorf("FAIL:\n expected: %v\neffective: %v", expected, effective)
+		t.Errorf("FAIL:\n expected: %#v\neffective: %#v", expected, effective)
 	}
 }
 
@@ -70,4 +70,23 @@ func TestRawDiskTrim(t *testing.T) {
 		Trim: true,
 	}
 	checkEqual(t, "ahci-hd,test.raw", disk.AsArgument())
+}
+
+func newDisk(t *testing.T, p string, s int) Disk {
+	res, err := NewDisk(p, s)
+	checkEqual(t, nil, err)
+	return res
+}
+
+func TestNewDisk(t *testing.T) {
+	{
+		var ref Disk = &QcowDisk{Path: "/test.qcow2", Size: 1}
+		checkEqual(t, ref, newDisk(t, "/test.qcow2", 1))
+		checkEqual(t, ref, newDisk(t, "file:///test.qcow2", 1))
+	}
+	{
+		var ref Disk = &RawDisk{Path: "/test.raw", Size: 1, Trim: true}
+		checkEqual(t, ref, newDisk(t, "/test.raw", 1))
+		checkEqual(t, ref, newDisk(t, "file:///test.raw", 1))
+	}
 }

--- a/go/hyperkit.go
+++ b/go/hyperkit.go
@@ -289,33 +289,33 @@ func (h *HyperKit) execute(cmdline string) error {
 		}
 	}
 
-	for idx, config := range h.Disks {
-		if config.Path == "" {
+	for idx, disk := range h.Disks {
+		if disk.Path == "" {
 			if h.StateDir == "" {
 				return fmt.Errorf("Unable to create disk image when neither path nor state dir is set")
 			}
-			if config.Size <= 0 {
+			if disk.Size <= 0 {
 				return fmt.Errorf("Unable to create disk image when size is 0 or not set")
 			}
-			config.Path = filepath.Clean(filepath.Join(h.StateDir, fmt.Sprintf("disk%02d.img", idx)))
-			h.Disks[idx] = config
+			disk.Path = filepath.Clean(filepath.Join(h.StateDir, fmt.Sprintf("disk%02d.img", idx)))
+			h.Disks[idx] = disk
 		}
 
 		// assume the path could be a file:// uri with query params
 		// use the actual path from the parsed result
-		u, err := url.Parse(config.Path)
+		u, err := url.Parse(disk.Path)
 		if err != nil {
 			return err
 		}
 
 		if _, err = os.Stat(u.Path); os.IsNotExist(err) {
-			if config.Size != 0 {
-				err = CreateDiskImage(u.Path, config.Size)
+			if disk.Size != 0 {
+				err = CreateDiskImage(u.Path, disk.Size)
 				if err != nil {
 					return err
 				}
 			} else {
-				return fmt.Errorf("Disk image %s not found and unable to create it as size is not specified", config.Path)
+				return fmt.Errorf("Disk image %s not found and unable to create it as size is not specified", disk.Path)
 			}
 		}
 	}
@@ -364,8 +364,8 @@ func (h *HyperKit) IsRunning() bool {
 
 // isDisk checks if the specified path is used as a disk image
 func (h *HyperKit) isDisk(path string) bool {
-	for _, config := range h.Disks {
-		if filepath.Clean(path) == filepath.Clean(config.Path) {
+	for _, disk := range h.Disks {
+		if filepath.Clean(path) == filepath.Clean(disk.Path) {
 			return true
 		}
 	}

--- a/go/hyperkit.go
+++ b/go/hyperkit.go
@@ -86,7 +86,7 @@ type HyperKit struct {
 	// UUID is a string containing a UUID, it sets BIOS DMI UUID for the VM (as found in /sys/class/dmi/id/product_uuid on Linux).
 	UUID string `json:"uuid"`
 	// Disks contains disk images to use/create.
-	Disks []RawDisk `json:"disks"`
+	Disks []Disk `json:"disks"`
 	// ISOImage is the (optional) path to a ISO image to attach.
 	ISOImages []string `json:"iso"`
 

--- a/go/hyperkit.go
+++ b/go/hyperkit.go
@@ -86,7 +86,7 @@ type HyperKit struct {
 	// UUID is a string containing a UUID, it sets BIOS DMI UUID for the VM (as found in /sys/class/dmi/id/product_uuid on Linux).
 	UUID string `json:"uuid"`
 	// Disks contains disk images to use/create.
-	Disks []DiskConfig `json:"disks"`
+	Disks []RawDisk `json:"disks"`
 	// ISOImage is the (optional) path to a ISO image to attach.
 	ISOImages []string `json:"iso"`
 

--- a/go/hyperkit.go
+++ b/go/hyperkit.go
@@ -431,7 +431,10 @@ func (h *HyperKit) buildArgs(cmdline string) {
 	}
 
 	if h.VSock {
-		path := defaultString(h.VSockDir, h.StateDir)
+		path := h.VSockDir
+		if path == "" {
+			path = h.StateDir
+		}
 		l := fmt.Sprintf("%d,virtio-sock,guest_cid=%d,path=%s", nextSlot, h.VSockGuestCID, path)
 		if len(h.VSockPorts) > 0 {
 			l = fmt.Sprintf("%s,guest_forwards=%s", l, intArrayToString(h.VSockPorts, ";"))
@@ -649,11 +652,4 @@ func getHome() string {
 		return usr.HomeDir
 	}
 	return os.Getenv("HOME")
-}
-
-func defaultString(a, b string) string {
-	if a != "" {
-		return a
-	}
-	return b
 }

--- a/go/hyperkit.go
+++ b/go/hyperkit.go
@@ -244,6 +244,7 @@ func (h *HyperKit) Start(cmdline string) error {
 }
 
 func (h *HyperKit) execute(cmdline string) error {
+	h.log.Printf("hyperkit: execute %#v", h)
 	var err error
 	// Sanity checks on configuration
 	if h.Console == ConsoleFile && h.StateDir == "" {
@@ -528,6 +529,8 @@ func (h *HyperKit) buildArgs(cmdline string) {
 
 	h.Arguments = a
 	h.CmdLine = h.HyperKit + " " + strings.Join(a, " ")
+	h.log.Printf("hyperkit: Arguments: %#v", h.Arguments)
+	h.log.Printf("hyperkit: CmdLine: %#v", h.CmdLine)
 }
 
 // Execute hyperkit and plumb stdin/stdout/stderr.
@@ -576,6 +579,7 @@ func (h *HyperKit) execHyperKit() error {
 			}()
 		}
 	} else if h.log != nil {
+		h.log.Printf("hyperkit: Redirecting stdout/stderr to logger")
 		stdoutChan := make(chan string)
 		stderrChan := make(chan string)
 		stdout, err := cmd.StdoutPipe()
@@ -604,25 +608,32 @@ func (h *HyperKit) execHyperKit() error {
 		}()
 	}
 
+	h.log.Printf("hyperkit: Starting %#v", cmd)
 	err := cmd.Start()
 	if err != nil {
 		return err
 	}
 	h.Pid = cmd.Process.Pid
+	h.log.Printf("hyperkit: Pid is %v", h.Pid)
 	h.process = cmd.Process
 	err = h.writeState()
 	if err != nil {
+		h.log.Printf("hyperkit: Cannot write state: %v, killing %v", err, h.Pid)
 		h.process.Kill()
 		return err
 	}
 	if !h.background {
+		h.log.Printf("hyperkit: Waiting for %#v", cmd)
 		err = cmd.Wait()
 		if err != nil {
 			return err
 		}
 	} else {
 		// Make sure we reap the child when it exits
-		go cmd.Wait()
+		go func() {
+			h.log.Printf("hyperkit: Waiting for %#v", cmd)
+			cmd.Wait()
+		}()
 	}
 	return nil
 }

--- a/go/hyperkit.go
+++ b/go/hyperkit.go
@@ -466,12 +466,7 @@ func (h *HyperKit) buildArgs(cmdline string) {
 	}
 
 	for _, p := range h.Disks {
-		// Default the driver to virtio-blk
-		driver := "virtio-blk"
-		if p.Driver != "" {
-			driver = p.Driver
-		}
-		arg := fmt.Sprintf("%d:0,%s,%s", nextSlot, driver, p.Path)
+		arg := fmt.Sprintf("%d:0,%s,%s", nextSlot, defaultString(p.Driver, "virtio-blk"), p.Path)
 
 		// Add on a format instruction if specified.
 		if p.Format != "" {
@@ -699,4 +694,11 @@ func getHome() string {
 		return usr.HomeDir
 	}
 	return os.Getenv("HOME")
+}
+
+func defaultString(a, b string) string {
+	if a != "" {
+		return a
+	}
+	return b
 }

--- a/go/log.go
+++ b/go/log.go
@@ -1,0 +1,50 @@
+package hyperkit
+
+import (
+	"fmt"
+	golog "log"
+)
+
+// Logger is an interface for logging.
+type Logger interface {
+	// Debugf logs a message with "debug" severity (very verbose).
+	Debugf(format string, v ...interface{})
+	// Infof logs a message with "info" severity (less verbose).
+	Infof(format string, v ...interface{})
+	// Errorf logs an (non-fatal) error.
+	Errorf(format string, v ...interface{})
+	// Fatalf logs a fatal error message, and exits 1.
+	Fatalf(format string, v ...interface{})
+}
+
+// StandardLogger makes the go standard logger comply to our Logger interface.
+type StandardLogger struct{}
+
+// Debugf logs a message with "debug" severity.
+func (*StandardLogger) Debugf(f string, v ...interface{}) {
+	golog.Printf("DEBUG: %v", fmt.Sprintf(f, v...))
+}
+
+// Infof logs a message with "info" severity.
+func (*StandardLogger) Infof(f string, v ...interface{}) {
+	golog.Printf("INFO : %v", fmt.Sprintf(f, v...))
+}
+
+// Errorf logs an (non-fatal) error.
+func (*StandardLogger) Errorf(f string, v ...interface{}) {
+	golog.Printf("ERROR: %v", fmt.Sprintf(f, v...))
+}
+
+// Fatalf logs a fatal error message, and exits 1.
+func (*StandardLogger) Fatalf(f string, v ...interface{}) {
+	golog.Fatalf("FATAL: %v", fmt.Sprintf(f, v...))
+}
+
+// Log receives stdout/stderr of the hyperkit process itself, if set.
+// It defaults to the go standard logger.
+var log Logger = &StandardLogger{}
+
+// SetLogger sets the logger to use.
+func SetLogger(l Logger) {
+	log = l
+}

--- a/go/pty_util_fallback.go
+++ b/go/pty_util_fallback.go
@@ -3,22 +3,21 @@
 package hyperkit
 
 import (
-	"log"
 	"os"
 )
 
 func saneTerminal(f *os.File) error {
-	log.Fatal("Function not supported on your OS")
+	log.Fatalf("Function not supported on your OS")
 	return nil
 }
 
 func setRaw(f *os.File) error {
-	log.Fatal("Function not supported on your OS")
+	log.Fatalf("Function not supported on your OS")
 	return nil
 }
 
 // isTerminal checks if the provided file is a terminal
 func isTerminal(f *os.File) bool {
-	log.Fatal("Function not supported on your OS")
+	log.Fatalf("Function not supported on your OS")
 	return false
 }

--- a/go/sample/main.go
+++ b/go/sample/main.go
@@ -146,28 +146,28 @@ func (d *disks) Set(v string) error {
 		return fmt.Errorf("Empty disk config")
 	}
 
-	var config hyperkit.DiskConfig
-	var err error
+	var disk hyperkit.DiskConfig
 	for _, kv := range strings.Split(v, ",") {
 		p := strings.SplitN(kv, "=", 2)
 		if len(p) == 1 { // Assume no key is a path
-			if config.Path != "" {
+			if disk.Path != "" {
 				return fmt.Errorf("Invalid disk config, path already set")
 			}
-			config.Path = p[0]
+			disk.Path = p[0]
 		} else {
 			switch p[0] {
 			case "size":
-				if config.Size, err = strconv.Atoi(p[1]); err != nil {
+				var err error
+				if disk.Size, err = strconv.Atoi(p[1]); err != nil {
 					return err
 				}
 			case "file":
-				config.Path = p[1]
+				disk.Path = p[1]
 			default:
 				return fmt.Errorf("Unrecognised disk config key: %s", p[0])
 			}
 		}
 	}
-	*d = append(*d, config)
+	*d = append(*d, disk)
 	return nil
 }

--- a/go/sample/main.go
+++ b/go/sample/main.go
@@ -134,7 +134,7 @@ func main() {
 
 }
 
-type disks []hyperkit.DiskConfig
+type disks []hyperkit.RawDisk
 
 func (d *disks) String() string {
 	return fmt.Sprintf("%v", *d)
@@ -146,7 +146,7 @@ func (d *disks) Set(v string) error {
 		return fmt.Errorf("Empty disk config")
 	}
 
-	var disk hyperkit.DiskConfig
+	var disk hyperkit.RawDisk
 	for _, kv := range strings.Split(v, ",") {
 		p := strings.SplitN(kv, "=", 2)
 		if len(p) == 1 { // Assume no key is a path

--- a/go/sample/main.go
+++ b/go/sample/main.go
@@ -150,22 +150,21 @@ func (d *disks) Set(v string) error {
 	for _, kv := range strings.Split(v, ",") {
 		p := strings.SplitN(kv, "=", 2)
 		if len(p) == 1 { // Assume no key is a path
+			p = []string{"file", kv}
+		}
+		switch p[0] {
+		case "size":
+			var err error
+			if disk.Size, err = strconv.Atoi(p[1]); err != nil {
+				return err
+			}
+		case "file":
 			if disk.Path != "" {
 				return fmt.Errorf("Invalid disk config, path already set")
 			}
-			disk.Path = p[0]
-		} else {
-			switch p[0] {
-			case "size":
-				var err error
-				if disk.Size, err = strconv.Atoi(p[1]); err != nil {
-					return err
-				}
-			case "file":
-				disk.Path = p[1]
-			default:
-				return fmt.Errorf("Unrecognised disk config key: %s", p[0])
-			}
+			disk.Path = p[1]
+		default:
+			return fmt.Errorf("Unrecognised disk config key: %s", p[0])
 		}
 	}
 	*d = append(*d, disk)

--- a/go/sample/main.go
+++ b/go/sample/main.go
@@ -134,7 +134,7 @@ func main() {
 
 }
 
-type disks []hyperkit.RawDisk
+type disks []hyperkit.Disk
 
 func (d *disks) String() string {
 	return fmt.Sprintf("%v", *d)
@@ -167,6 +167,6 @@ func (d *disks) Set(v string) error {
 			return fmt.Errorf("Unrecognised disk config key: %s", p[0])
 		}
 	}
-	*d = append(*d, disk)
+	*d = append(*d, &disk)
 	return nil
 }


### PR DESCRIPTION
This is the changes that are currently running in Docker for Mac.  I have removed the stylistic issues (adjusted comments, scope reduction, etc.) that were discussed in https://github.com/moby/hyperkit/pull/167.  The `defaultString` function is removed at the end.

Cheers!