### PR TITLE
Go: revamp the Start/Run procedures

### DIFF
--- a/go/hyperkit.go
+++ b/go/hyperkit.go
@@ -225,8 +225,9 @@ func (h *HyperKit) Start(cmdline string) error {
 	return h.execute(cmdline)
 }
 
-func (h *HyperKit) execute(cmdline string) error {
-	log.Debugf("hyperkit: execute %#v", h)
+// check validates `h`.  It also creates the disks if needed.
+func (h *HyperKit) check() error {
+	log.Debugf("hyperkit: check %#v", h)
 	var err error
 	// Sanity checks on configuration
 	if h.Console == ConsoleFile && h.StateDir == "" {
@@ -294,10 +295,17 @@ func (h *HyperKit) execute(cmdline string) error {
 			return err
 		}
 	}
+	return nil
+}
 
+func (h *HyperKit) execute(cmdline string) error {
+	log.Debugf("hyperkit: execute %#v", h)
+	if err := h.check(); err != nil {
+		return err
+	}
 	// Run
 	h.buildArgs(cmdline)
-	err = h.execHyperKit()
+	err := h.execHyperKit()
 	if err != nil {
 		return err
 	}

--- a/go/hyperkit.go
+++ b/go/hyperkit.go
@@ -236,7 +236,7 @@ func (h *HyperKit) Start(cmdline string) error {
 		return err
 	}
 	h.buildArgs(cmdline)
-	cmd, err := h.makeCommand()
+	cmd, err := h.execute()
 	if err != nil {
 		return err
 	}
@@ -494,9 +494,9 @@ func (h *HyperKit) buildArgs(cmdline string) {
 	log.Debugf("hyperkit: CmdLine: %#v", h.CmdLine)
 }
 
-// makeCommand forges the command to run hyperkit, runs and returns it.
+// execute forges the command to run hyperkit, runs and returns it.
 // It also plumbs stdin/stdout/stderr.
-func (h *HyperKit) makeCommand() (*exec.Cmd, error) {
+func (h *HyperKit) execute() (*exec.Cmd, error) {
 
 	cmd := exec.Command(h.HyperKit, h.Arguments...)
 	if h.Argv0 != "" {

--- a/go/sample/main.go
+++ b/go/sample/main.go
@@ -121,7 +121,7 @@ func main() {
 
 	if *bg {
 		h.Console = hyperkit.ConsoleFile
-		err = h.Start("console=ttyS0")
+		_, err = h.Start("console=ttyS0")
 
 	} else {
 		err = h.Run("console=ttyS0")
@@ -131,7 +131,6 @@ func main() {
 		fmt.Println(h.Arguments)
 		log.Fatalln("Error creating hyperkit: ", err)
 	}
-
 }
 
 type disks []hyperkit.Disk


### PR DESCRIPTION
Currently we offer two means to run hyperkit: `Start` and `Run`. Both run the process in background (using `exec.Cmd.Start`), in order to be able to save the state when launching succeeded.

Both wait for the command to finish.  `Run` returns the exit status. `Start` waits in a goroutine and discard the result.

As a result, the user has no clean means to run in background and get the exit status.  The `Start` function discards the exit status.  But since `Run` is blocking, the caller must run it in a goroutine.  Therefore the callers needs to watch the process to know when it is actually running (e.g., by watching `h.Pid`).

Revamp this.
- First, make changes easier by isolating the checking and the `exec.Cmd` creation parts into their own functions
- Provide the HyperKit struct with a channel to publish the result of waiting for hyperkit
- Move what remains of `execute`/`execHyperKit` into `Start`
- Write `Run` on top of `Start`.

I have not included the `exec.Cmd` in the `HyperKit` struct, but that was an option.

Preparing the `Cmd` and leaving it to the user was also an option.  I stayed with the current approach.

Docker for Mac is made cleaner/faster thanks to these changes.
```diff
-   hypErr := make(chan error, 1)
-
-   go func() { hypErr <- h.Run("") }()
-
-   // Wait for the process to be created.
-   for i := 0; i < 10; i++ {
-           if h.Pid != 0 {
-                   break
-           }
-           select {
-           case err := <-hypErr:
-                   log.Fatalf("Hyperkit failed to start: %v", err)
-           default:
-                   log.Infof("Waiting for %#v to start", h)
-                   time.Sleep(500 * time.Millisecond)
-           }
-       }
-   if h.Pid == 0 {
-           log.Fatalf("hyperkit did not start")
-   }
-   return h.Pid, hypErr
+   if err := h.Start(""); err != nil {
+           log.Fatalf("Hyperkit failed to start: %v", err)
+       }
+   return h.Pid, h.ErrorCh
```