### PR TITLE
Go: add logs about qcow compaction and runtime checks

### DIFF
--- a/go/disk.go
+++ b/go/disk.go
@@ -302,6 +302,13 @@ func (d *QcowDisk) Exists() bool {
 
 // Ensure creates the disk image if needed, and resizes it if needed.
 func (d *QcowDisk) Ensure() error {
+	if d.Trim {
+		log.Infof("%v: TRIM is enabled; recycling thread will keep %v sectors free and will compact after %v more sectors are free",
+			d, d.KeepErased, d.CompactAfter)
+	}
+	if d.RuntimeAsserts {
+		log.Warnf("%v: Expensive runtime checks are enabled", d)
+	}
 	return ensure(d)
 }
 

--- a/go/log.go
+++ b/go/log.go
@@ -11,6 +11,8 @@ type Logger interface {
 	Debugf(format string, v ...interface{})
 	// Infof logs a message with "info" severity (less verbose).
 	Infof(format string, v ...interface{})
+	// Warnf logs a message with "warn" (non-fatal) severity.
+	Warnf(format string, v ...interface{})
 	// Errorf logs an (non-fatal) error.
 	Errorf(format string, v ...interface{})
 	// Fatalf logs a fatal error message, and exits 1.
@@ -28,6 +30,11 @@ func (*StandardLogger) Debugf(f string, v ...interface{}) {
 // Infof logs a message with "info" severity.
 func (*StandardLogger) Infof(f string, v ...interface{}) {
 	golog.Printf("INFO : %v", fmt.Sprintf(f, v...))
+}
+
+// Warnf logs a message with "warn" (non-fatal) severity.
+func (*StandardLogger) Warnf(f string, v ...interface{}) {
+	golog.Printf("WARN : %v", fmt.Sprintf(f, v...))
 }
 
 // Errorf logs an (non-fatal) error.


### PR DESCRIPTION
These logs are currently emitted by Docker for Mac, but I believe they make more sense here.