### PR TITLE
Go: remove the ExtraFiles field

### DIFF
--- a/go/hyperkit.go
+++ b/go/hyperkit.go
@@ -121,16 +121,6 @@ type HyperKit struct {
 	// connected to. ConsoleStdio and ConsoleFile are supported.
 	Console int `json:"console"`
 
-	// ExtraFiles is exactly exec.Cmd.ExtraFiles.  It specifies
-	// additional open files to be inherited by the hyperkit
-	// process. It does not include standard input, standard
-	// output, or standard error. If non-nil, entry i becomes file
-	// descriptor 3+i.
-	//
-	// It can be used to keep some files alive even if the parent
-	// process died unexpectedly.
-	ExtraFiles []*os.File `json:"extra_files"`
-
 	// Below here are internal members, but they are exported so
 	// that they are written to the state json file, if configured.
 
@@ -498,7 +488,6 @@ func (h *HyperKit) execute() (*exec.Cmd, error) {
 		cmd.Args[0] = h.Argv0
 	}
 	cmd.Env = os.Environ()
-	cmd.ExtraFiles = h.ExtraFiles
 
 	// Plumb in stdin/stdout/stderr.
 	//


### PR DESCRIPTION
It was introduced for Docker for Mac in d1a5c32a404a86facc5800d962901b5e7a1783d9, so that we could ensure that Docker for Mac's lockfile would be preserved even if it were to crash. This use was removed in 2bedc1969f8c6893678fdef55e90e734c170c42c since djs55 had qcow-tool deal with the lock itself.
