### PR TITLE
Go: remove the reloading from json

### DIFF
--- a/go/hyperkit.go
+++ b/go/hyperkit.go
@@ -173,39 +173,6 @@ func New(hyperkit, vpnkitsock, statedir string) (*HyperKit, error) {
 	return &h, nil
 }
 
-// FromState reads a json file from statedir and populates a HyperKit structure.
-func FromState(statedir string) (*HyperKit, error) {
-	b, err := ioutil.ReadFile(filepath.Join(statedir, jsonFile))
-	if err != nil {
-		return nil, fmt.Errorf("Can't read json file: %s", err)
-	}
-	h := &HyperKit{}
-	err = json.Unmarshal(b, h)
-	if err != nil {
-		return nil, fmt.Errorf("Can't parse json file: %s", err)
-	}
-
-	// Make sure the pid written by hyperkit is the same as in the json
-	d, err := ioutil.ReadFile(filepath.Join(statedir, pidFile))
-	if err != nil {
-		return nil, err
-	}
-	pid, err := strconv.Atoi(string(d[:]))
-	if err != nil {
-		return nil, err
-	}
-	if h.Pid != pid {
-		return nil, fmt.Errorf("pids do not match %d != %d", h.Pid, pid)
-	}
-
-	h.process, err = os.FindProcess(h.Pid)
-	if err != nil {
-		return nil, err
-	}
-
-	return h, nil
-}
-
 // SetLogger sets the log instance to use for the output of the hyperkit process itself (not the console of the VM).
 // This is only relevant when Console is set to ConsoleFile
 func (h *HyperKit) SetLogger(l Logger) {

--- a/go/sample/main.go
+++ b/go/sample/main.go
@@ -4,7 +4,6 @@
 package main
 
 import (
-	"encoding/json"
 	"flag"
 	"fmt"
 	"log"
@@ -56,32 +55,7 @@ func main() {
 	cmd := flag.Args()
 
 	if len(cmd) != 0 {
-		if *statedir == "" {
-			log.Fatalln("Specify existing state directory for: ", cmd[0])
-		}
-		h, err := hyperkit.FromState(*statedir)
-		if err != nil {
-			log.Fatalln("Error getting hyperkit: ", err)
-		}
-		switch cmd[0] {
-		case "info":
-			fmt.Println("Running: ", h.IsRunning())
-			s, _ := json.MarshalIndent(h, "", "  ")
-			fmt.Println(string(s))
-			return
-		case "stop", "kill":
-			err := h.Stop()
-			if err != nil {
-				log.Fatalln("Error stopping hyperkit: ", err)
-			}
-			err = h.Remove(false)
-			if err != nil {
-				log.Fatalln("Error removing state: ", err)
-			}
-			return
-		default:
-			log.Fatalln("Unknown command: ", cmd[0])
-		}
+		log.Fatalf("Unexpected arguments: %v", cmd)
 	}
 
 	h, err := hyperkit.New(*hk, *vpnkitsock, *statedir)


### PR DESCRIPTION
In https://github.com/moby/hyperkit/pull/174#issuecomment-356305949 it was discussed that this feature might be unused and useless.   This PR is meant to sort this out.