### PR TITLE
CI: also publish the COMMIT

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -192,3 +192,25 @@ test: $(TARGET) test/vmlinuz test/initrd.gz
 
 test-qcow: $(TARGET) test/vmlinuz test/initrd.gz
 	@(cd test && ./test_linux_qcow.exp)
+
+
+## ----------- ##
+## Artifacts.  ##
+## ----------- ##
+
+.PHONY: artifacts
+artifacts: build/LICENSE build/COMMIT
+
+.PHONY: build/LICENSE
+build/LICENSE:
+	@echo "  GEN     " $@
+	@find src -type f | xargs awk '/^\/\*-/{p=1;print FILENAME ":";print;next} p&&/^.*\*\//{print;print "";p=0};p' > $@.tmp
+	@opam config exec -- make -C repo list-licenses
+	@cat repo/OCAML-LICENSES >> $@.tmp
+	@mv $@.tmp $@
+
+.PHONY: build/COMMIT
+build/COMMIT:
+	@echo "  GEN     " $@
+	@git rev-parse HEAD > $@.tmp
+	@mv $@.tmp $@

--- a/circle.yml
+++ b/circle.yml
@@ -2,6 +2,7 @@ general:
   artifacts:
     - build/hyperkit
     - build/hyperkit.sym
+    - build/COMMIT
     - build/LICENSE
 machine:
   xcode:
@@ -33,7 +34,4 @@ test:
     - ln -s $(pwd) "$PROJECT_ROOT"
     - brew install golang
     - (cd go; make ci)
-    # LICENSE related steps
-    - find src -type f | xargs awk '/^\/\*-/{p=1;print FILENAME ":";print;next} p&&/^.*\*\//{print;print "";p=0};p' > build/LICENSE
-    - opam config exec -- make -C repo list-licenses
-    - cat repo/OCAML-LICENSES >> build/LICENSE
+    - make artifacts


### PR DESCRIPTION
So that when we download an artifact we can relate it to a precise commit.
