### PR TITLE
Minor tweaks to go bindings

### DIFF
--- a/go/disk.go
+++ b/go/disk.go
@@ -62,7 +62,7 @@ func GetDiskFormat(path string) DiskFormat {
 	switch ext := filepath.Ext(path); ext {
 	case ".qcow2":
 		return DiskFormatQcow
-	case ".raw":
+	case ".raw", ".img":
 		return DiskFormatRaw
 	default:
 		log.Debugf("Unknown disk extension %q, will use raw format", path)

--- a/go/hyperkit.go
+++ b/go/hyperkit.go
@@ -163,12 +163,6 @@ func New(hyperkit, vpnkitsock, statedir string) (*HyperKit, error) {
 	return &h, nil
 }
 
-// SetLogger sets the log instance to use for the output of the hyperkit process itself (not the console of the VM).
-// This is only relevant when Console is set to ConsoleFile
-func (h *HyperKit) SetLogger(l Logger) {
-	SetLogger(l)
-}
-
 // Run the VM with a given command line until it exits.
 func (h *HyperKit) Run(cmdline string) error {
 	errCh, err := h.Start(cmdline)


### PR DESCRIPTION
- Remove per hyperkit instance SetLogger(). It's not per instance
- Add '.img' as a recognised raw disk extension