### PR TITLE
Simplify logs

### DIFF
--- a/go/hyperkit.go
+++ b/go/hyperkit.go
@@ -500,7 +500,6 @@ func (h *HyperKit) execute() (*exec.Cmd, error) {
 		stream(stdout, stdoutChan)
 		stream(stderr, stderrChan)
 
-		done := make(chan struct{})
 		go func() {
 			for {
 				select {
@@ -508,8 +507,6 @@ func (h *HyperKit) execute() (*exec.Cmd, error) {
 					log.Infof("%s", stderrl)
 				case stdoutl := <-stdoutChan:
 					log.Infof("%s", stdoutl)
-				case <-done:
-					return
 				}
 			}
 		}()

--- a/go/hyperkit.go
+++ b/go/hyperkit.go
@@ -487,8 +487,6 @@ func (h *HyperKit) execute() (*exec.Cmd, error) {
 		}
 	} else if log != nil {
 		log.Debugf("hyperkit: Redirecting stdout/stderr to logger")
-		stdoutChan := make(chan string)
-		stderrChan := make(chan string)
 		stdout, err := cmd.StdoutPipe()
 		if err != nil {
 			return nil, err
@@ -497,19 +495,8 @@ func (h *HyperKit) execute() (*exec.Cmd, error) {
 		if err != nil {
 			return nil, err
 		}
-		stream(stdout, stdoutChan)
-		stream(stderr, stderrChan)
-
-		go func() {
-			for {
-				select {
-				case stderrl := <-stderrChan:
-					log.Infof("%s", stderrl)
-				case stdoutl := <-stdoutChan:
-					log.Infof("%s", stdoutl)
-				}
-			}
-		}()
+		go logStream(stdout, "stdout")
+		go logStream(stderr, "stderr")
 	}
 
 	log.Debugf("hyperkit: Starting %#v", cmd)
@@ -543,18 +530,18 @@ func (h *HyperKit) writeState() error {
 	return ioutil.WriteFile(filepath.Join(h.StateDir, jsonFile), []byte(s), 0644)
 }
 
-func stream(r io.ReadCloser, dest chan<- string) {
-	go func() {
-		defer r.Close()
-		reader := bufio.NewReader(r)
-		for {
-			line, err := reader.ReadString('\n')
-			if err != nil {
-				return
-			}
-			dest <- line
+// logStream redirects a file to the logs.
+func logStream(r io.ReadCloser, name string) {
+	defer r.Close()
+	reader := bufio.NewReader(r)
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			log.Warnf("hyperkit: failed to read %v: %v", name, err)
+			break
 		}
-	}()
+		log.Infof("hyperkit: %v: %v", name, line)
+	}
 }
 
 // checkHyperKit tries to find and/or validate the path of hyperkit

--- a/go/pty_util_fallback.go
+++ b/go/pty_util_fallback.go
@@ -7,17 +7,17 @@ import (
 )
 
 func saneTerminal(f *os.File) error {
-	log.Fatalf("Function not supported on your OS")
+	log.Fatalf("hyperkit: Function not supported on your OS")
 	return nil
 }
 
 func setRaw(f *os.File) error {
-	log.Fatalf("Function not supported on your OS")
+	log.Fatalf("hyperkit: Function not supported on your OS")
 	return nil
 }
 
 // isTerminal checks if the provided file is a terminal
 func isTerminal(f *os.File) bool {
-	log.Fatalf("Function not supported on your OS")
+	log.Fatalf("hyperkit: Function not supported on your OS")
 	return false
 }


### PR DESCRIPTION
- remove useless code
- simplify log redirection
- make sure all the logs are reported as `hyperkit:`

Instead of log redirection for hyperkit(.exe) it would be much more convenient for Docker for Mac that hyperkit used aslog directly, so that its logs are properly credited to it rather than to the caller, which happens to be com.docker.driver.

cc: @djs55 