### PR TITLE
Offer a means to send the tty to the Apple log system

### DIFF
--- a/CODINGSTYLE.md
+++ b/CODINGSTYLE.md
@@ -5,7 +5,7 @@ coding style should follow the
 
 You may use tools like
 [uncrustify](http://uncrustify.sourceforge.net/) with this
-[config file](https://github.com/freebsd/pkg/blob/master/freebsd.cfg)
+[config file](https://raw.githubusercontent.com/freebsd/pkg/master/freebsd.cfg)
 for *new* code, though the result may not be perfect.
 
 Keep in mind that, especially for most of the `bhyve` derived code, it

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ HYPERKIT_LIB_SRC := \
 	src/lib/fwctl.c \
 	src/lib/inout.c \
 	src/lib/ioapic.c \
+	src/lib/log.c \
 	src/lib/md5c.c \
 	src/lib/mem.c \
 	src/lib/mevent.c \

--- a/go/hyperkit.go
+++ b/go/hyperkit.go
@@ -422,7 +422,7 @@ func (h *HyperKit) buildArgs(cmdline string) {
 
 	if h.Console == ConsoleStdio && isTerminal(os.Stdout) {
 		a = append(a, "-l", "com1,stdio")
-	} else if h.StateDir != "" {
+	} else {
 		a = append(a, "-l", fmt.Sprintf("com1,autopty=%s/tty,log=%s/console-ring", h.StateDir, h.StateDir))
 	}
 

--- a/src/include/xhyve/log.h
+++ b/src/include/xhyve/log.h
@@ -1,0 +1,7 @@
+#pragma once
+
+/* Initialize ASL logger and local buffer. */
+void log_init(void);
+
+/* Send one character to the logger: wait for full lines before actually sending. */
+void log_put(uint8_t _c);

--- a/src/lib/log.c
+++ b/src/lib/log.c
@@ -1,0 +1,50 @@
+#include <asl.h>
+#include <pwd.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <time.h>
+
+#include <SystemConfiguration/SystemConfiguration.h>
+
+#include <xhyve/log.h>
+
+static aslclient log_client = NULL;
+static aslmsg log_msg = NULL;
+
+static unsigned char buf[4096];
+/* Index of the _next_ character to insert in the buffer. */
+static size_t buf_idx = 0;
+
+/* asl is deprecated in favor of os_log starting with macOS 10.12.  */
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
+/* Initialize ASL logger and local buffer. */
+void log_init(void)
+{
+	log_client = asl_open(NULL, NULL, 0);
+	log_msg = asl_new(ASL_TYPE_MSG);
+}
+
+
+/* Send the content of the buffer to the logger. */
+static void log_flush(void)
+{
+	buf[buf_idx] = 0;
+	asl_log(log_client, log_msg, ASL_LEVEL_NOTICE, "%s", buf);
+	buf_idx = 0;
+}
+
+
+/* Send one character to the logger: wait for full lines before actually sending. */
+void log_put(uint8_t c)
+{
+	if ((c == '\n') || (c == 0)) {
+		log_flush();
+	} else {
+		if (buf_idx + 2 >= sizeof(buf)) {
+			log_flush();
+		}
+		buf[buf_idx] = c;
+		++buf_idx;
+	}
+}

--- a/src/lib/uart_emul.c
+++ b/src/lib/uart_emul.c
@@ -45,9 +45,9 @@
 #include <xhyve/mevent.h>
 #include <xhyve/uart_emul.h>
 
-#define	COM1_BASE      	0x3F8
+#define	COM1_BASE	0x3F8
 #define COM1_IRQ	4
-#define	COM2_BASE      	0x2F8
+#define	COM2_BASE	0x2F8
 #define COM2_IRQ	3
 
 #define	DEFAULT_RCLK	1843200
@@ -91,7 +91,7 @@ struct fifo {
 struct ttyfd {
 	bool	opened;
 	int	fd;		/* tty device file descriptor */
-	int 	sfd;
+	int	sfd;
 	char *name; /* slave pty name when using autopty*/
 	struct termios tio_orig, tio_new;    /* I/O Terminals */
 };
@@ -427,7 +427,7 @@ uart_write(struct uart_softc *sc, int offset, uint8_t value)
 		}
 	}
 
-        switch (offset) {
+	switch (offset) {
 	case REG_DATA:
 		if (sc->mcr & MCR_LOOPBACK) {
 			if (rxfifo_putchar(sc, value) != 0)
@@ -681,15 +681,15 @@ uart_tty_backend(struct uart_softc *sc, const char *backend)
 static char *
 copy_up_to_comma(const char *from)
 {
-        char *comma = strchr(from, ',');
-        char *tmp = NULL;
-        if (comma == NULL) {
-                tmp = strdup(from); /* rest of string */
-        } else {
-                ptrdiff_t length = comma - from;
-                tmp = strndup(from, (size_t)length);
-        }
-        return tmp;
+	char *comma = strchr(from, ',');
+	char *tmp = NULL;
+	if (comma == NULL) {
+		tmp = strdup(from); /* rest of string */
+	} else {
+		ptrdiff_t length = comma - from;
+		tmp = strndup(from, (size_t)length);
+	}
+	return tmp;
 }
 
 int


### PR DESCRIPTION
This is https://github.com/moby/hyperkit/pull/196 rewritten with comments from @rn and @ijc integrated.

On Docker for Windows, all the logs are aggregated: GUI, LinuxKit, etc.  Currently debugging on Docker for Mac is less easy, in particular because LinuxKit's log are sent to the consolefile rings of fixed sized buffers.  As a result, it's hard to find the interleaving of actions between Docker for Mac and LinuxKit, the console files are fragmented and full of '\0', etc.

It is possible to have hyperkit redirect the tty's output to its stderr/stdout, and then its caller (Docker for Mac's driver) could redirect these streams to the logger.  Unfortunately on recent macOS releases, asl is replaced by os_log which uses exclusively the path of the executable as source (changing `argv[0]` is useless).  As a result, hyperkit's logs are "credited" to the driver.

The most elegant approach is to embrace asl/os_log.

Currently Docker for Mac still targets 10.11, and os_log appeared in macOS 10.12, so we cannot use directly os_log's API, we use it through the asl shim.

- add a new device configuration, asl, that sends the tty's output to asl
- in Go, add a new ConsoleLog enum to enum it.

Since some of the logs use escapes for the terminal, escapes appear in the logs.   But that's another issue.

    2018-03-30 10:09:04.784291 +0200	par défaut	75122	com.docker.hyperkit	\^[[34mINFO\^[[0m[0000] starting containerd                           \^[[34mmodule\^[[0m=containerd \^[[34mrevision\^[[0m=9b55aab90508bd389d7654c4baf173a981477d55 \^[[34mversion\^[[0m=v1.0.1
    2018-03-30 10:09:04.785597 +0200	par défaut	75122	com.docker.hyperkit	\^[[34mINFO\^[[0m[0000] loading plugin "io.containerd.content.v1.content"...  \^[[34mmodule\^[[0m=containerd \^[[34mtype\^[[0m=io.containerd.content.v1
    2018-03-30 10:09:04.786756 +0200	par défaut	75122	com.docker.hyperkit	\^[[34mINFO\^[[0m[0000] loading plugin "io.containerd.snapshotter.v1.btrfs"...  \^[[34mmodule\^[[0m=containerd \^[[34mtype\^[[0m=io.containerd.snapshotter.v1
    2018-03-30 10:09:04.788161 +0200	par défaut	75122	com.docker.hyperkit	\^[[33mWARN\^[[0m[0000] failed to load plugin io.containerd.snapshotter.v1.btrfs  \^[[33merror\^[[0m="path /var/lib/containerd/io.containerd.snapshotter.v1.btrfs must be a btrfs filesystem to be used with the btrfs snapshotter" \^[[33mmodule\^[[0m=containerd
