### PR TITLE
ci: bump to xcode 9.3 and minimum MacOS to 10.11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,11 +2,11 @@ version: 2
 jobs:
   build:
     macos:
-      xcode: "9.0"
+      xcode: "9.3.0"
     environment:
       # OPAM seems to be quite unhappy without $TERM and Circle doesn't seem to set one.
       TERM: vt100
-      MACOSX_DEPLOYMENT_TARGET: "10.10"
+      MACOSX_DEPLOYMENT_TARGET: "10.11"
       OPAM_REPO: repo/darwin
       OPAM_COMP: 4.03.0
       OPAMVERBOSE: 1


### PR DESCRIPTION
Also revert the Python workaround from f55b5442ad65188f0002264a08de38ca47350e4d
which was added in #202.

Signed-off-by: Ian Campbell <ijc@docker.com>

The removal of the Python workaround is optimistic/speculative in case this base image has a newer brew than the old one, if that turns out not to be the case I'll drop that hunk and continue to rely on #203.