### PR TITLE
go: Don't check for initrd

### DIFF
--- a/go/hyperkit.go
+++ b/go/hyperkit.go
@@ -231,8 +231,10 @@ func (h *HyperKit) check() error {
 		if _, err = os.Stat(h.Kernel); os.IsNotExist(err) {
 			return fmt.Errorf("Kernel %s does not exist", h.Kernel)
 		}
-		if _, err = os.Stat(h.Initrd); os.IsNotExist(err) {
-			return fmt.Errorf("initrd %s does not exist", h.Initrd)
+		if h.Initrd != "" {
+			if _, err = os.Stat(h.Initrd); os.IsNotExist(err) {
+				return fmt.Errorf("initrd %s does not exist", h.Initrd)
+			}
 		}
 	} else {
 		if _, err = os.Stat(h.Bootrom); os.IsNotExist(err) {


### PR DESCRIPTION
hyperkit happily boots with just a kernel (and the rootfs on
a disk device, for example). So, if booting in non-fw mode
only check for the kernel.

Signed-off-by: Rolf Neugebauer <rolf.neugebauer@docker.com>