### PR TITLE
Add Log directory and SATA NCQ Send and Receive Log.

### DIFF
--- a/src/lib/pci_ahci.c
+++ b/src/lib/pci_ahci.c
@@ -892,19 +892,36 @@ static void
 ahci_handle_read_log(struct ahci_port *p, int slot, uint8_t *cfis)
 {
 	struct ahci_cmd_hdr *hdr;
-	uint8_t buf[512];
+	uint32_t buf[128];
+	uint8_t *buf8 = (uint8_t *)buf;
+	uint16_t *buf16 = (uint16_t *)buf;
 
 	hdr = (struct ahci_cmd_hdr *)((void *) (p->cmd_lst + slot * AHCI_CL_SIZE));
-	if (p->atapi || hdr->prdtl == 0 || cfis[4] != 0x10 ||
-	    cfis[5] != 0 || cfis[9] != 0 || cfis[12] != 1 || cfis[13] != 0) {
+	if (p->atapi || hdr->prdtl == 0 || cfis[5] != 0 ||
+	    cfis[9] != 0 || cfis[12] != 1 || cfis[13] != 0) {
 		ahci_write_fis_d2h(p, slot, cfis,
 		    (ATA_E_ABORT << 8) | ATA_S_READY | ATA_S_ERROR);
 		return;
 	}
 
 	memset(buf, 0, sizeof(buf));
-	memcpy(buf, p->err_cfis, sizeof(p->err_cfis));
-	ahci_checksum(buf, sizeof(buf));
+	if (cfis[4] == 0x00) {  /* Log directory */
+		buf16[0x00] = 1; /* Version -- 1 */
+		buf16[0x10] = 1; /* NCQ Command Error Log -- 1 page */
+		buf16[0x13] = 1; /* SATA NCQ Send and Receive Log -- 1 page */
+	} else if (cfis[4] == 0x10) {   /* NCQ Command Error Log */
+		memcpy(buf8, p->err_cfis, sizeof(p->err_cfis));
+		ahci_checksum(buf8, sizeof(buf));
+	} else if (cfis[4] == 0x13) {   /* SATA NCQ Send and Receive Log */
+		if (blockif_candelete(p->bctx) && !blockif_is_ro(p->bctx)) {
+			buf[0x00] = 1;  /* SFQ DSM supported */
+			buf[0x01] = 1;  /* SFQ DSM TRIM supported */
+		}
+	} else {
+		ahci_write_fis_d2h(p, slot, cfis,
+		    (ATA_E_ABORT << 8) | ATA_S_READY | ATA_S_ERROR);
+		return;
+	}
 
 	if (cfis[2] == ATA_READ_LOG_EXT)
 		ahci_write_fis_piosetup(p);


### PR DESCRIPTION
This is a manual "cherry-pick" of FreeBSD bhyve commits:
- 9b141cb38697 ("Add Log directory and SATA NCQ Send and Receive Log.")
- 6f295d26ad99 ("Fix variable for sizeof() in previous commit.")

The main original commit message is:

commit 9b141cb386977064a49f9d035e7dee35b6b4d5d5
Author: mav <mav@FreeBSD.org>
Date:   Sun Apr 2 20:39:51 2017 +0000

    Add Log directory and SATA NCQ Send and Receive Log.

    Those are used at least by Linux guests to detect queued TRIM support.

    MFC after:      2 weeks
    Sponsored by:   iXsystems, Inc.

Signed-off-by: Rolf Neugebauer <rolf.neugebauer@docker.com>


I've ran a few kernel compiles and other relatively disk intensive loads through it and it was holding up.