### PR TITLE
Send (stdout/stderr) logs to the system logger

### DIFF
--- a/src/hyperkit.c
+++ b/src/hyperkit.c
@@ -145,6 +145,7 @@ usage(int code)
 		    "       -h: help\n"
 		    "       -H: vmexit from the guest on hlt\n"
 		    "       -l: LPC device configuration. Ex: -l com1,stdio -l com2,autopty -l com2,/dev/myownpty\n"
+		    "       -L: destination for logs: 'stderr' (default), or 'log'\n"
 		    "       -m: memory size in MB, may be suffixed with one of K, M, G or T\n"
 		    "       -P: vmexit from the guest on pause\n"
 		    "       -s: <slot,driver,configinfo> PCI slot config\n"
@@ -869,7 +870,7 @@ main(int argc, char *argv[])
 	rtc_localtime = 1;
 	fw = 0;
 
-	while ((c = getopt(argc, argv, "behvuwxMACHPWY:f:F:g:c:s:m:l:U:")) != -1) {
+	while ((c = getopt(argc, argv, "behvuwxMACHPWY:f:F:g:c:s:m:l:L:U:")) != -1) {
 		switch (c) {
 		case 'A':
 			acpi = 1;
@@ -901,6 +902,9 @@ main(int argc, char *argv[])
 				errx(EX_USAGE, "invalid lpc device "
 				    "configuration '%s'", optarg);
 			}
+			break;
+                case 'L':
+			log_set_destination(optarg);
 			break;
 		case 's':
 			if (pci_parse_slot(optarg) != 0)

--- a/src/hyperkit.c
+++ b/src/hyperkit.c
@@ -132,42 +132,45 @@ static uint64_t (*fw_func)(void);
 __attribute__ ((noreturn)) static void
 usage(int code)
 {
-
-        fprintf(stderr,
-                "Usage: %s [-behuwxMACHPWY] [-c vcpus] [-F <pidfile>] [-g <gdb port>] [-l <lpc>]\n"
-		"       %*s [-m mem] [-p vcpu:hostcpu] [-s <pci>] [-U uuid] -f <fw>\n"
-		"       -A: create ACPI tables\n"
-		"       -c: # cpus (default 1)\n"
-		"       -C: include guest memory in core file\n"
-		"       -e: exit on unhandled I/O access\n"
-		"       -f: firmware\n"
-		"       -F: pidfile\n"
-		"       -g: gdb port\n"
-		"       -h: help\n"
-		"       -H: vmexit from the guest on hlt\n"
-		"       -l: LPC device configuration. Ex: -l com1,stdio -l com2,autopty -l com2,/dev/myownpty\n"
-		"       -m: memory size in MB, may be suffixed with one of K, M, G or T\n"
-		"       -P: vmexit from the guest on pause\n"
-		"       -s: <slot,driver,configinfo> PCI slot config\n"
-		"       -u: RTC keeps UTC time\n"
-		"       -U: uuid\n"
-		"       -v: show build version\n"
-		"       -w: ignore unimplemented MSRs\n"
-		"       -W: force virtio to use single-vector MSI\n"
-		"       -x: local apic is in x2APIC mode\n"
-		"       -Y: disable MPtable generation\n",
-		progname, (int)strlen(progname), "");
-
+	if (code) {
+		printf("Usage: %s [-behuwxMACHPWY] [-c vcpus] [-F <pidfile>] [-g <gdb port>] [-l <lpc>]\n"
+		    "       %*s [-m mem] [-p vcpu:hostcpu] [-s <pci>] [-U uuid] -f <fw>\n"
+		    "       -A: create ACPI tables\n"
+		    "       -c: # cpus (default 1)\n"
+		    "       -C: include guest memory in core file\n"
+		    "       -e: exit on unhandled I/O access\n"
+		    "       -f: firmware\n"
+		    "       -F: pidfile\n"
+		    "       -g: gdb port\n"
+		    "       -h: help\n"
+		    "       -H: vmexit from the guest on hlt\n"
+		    "       -l: LPC device configuration. Ex: -l com1,stdio -l com2,autopty -l com2,/dev/myownpty\n"
+		    "       -m: memory size in MB, may be suffixed with one of K, M, G or T\n"
+		    "       -P: vmexit from the guest on pause\n"
+		    "       -s: <slot,driver,configinfo> PCI slot config\n"
+		    "       -u: RTC keeps UTC time\n"
+		    "       -U: uuid\n"
+		    "       -v: show build version\n"
+		    "       -w: ignore unimplemented MSRs\n"
+		    "       -W: force virtio to use single-vector MSI\n"
+		    "       -x: local apic is in x2APIC mode\n"
+		    "       -Y: disable MPtable generation\n",
+		    progname, (int)strlen(
+			    progname), "");
+	} else {
+		fprintf(stderr,
+		    "Try '%s --help' for more information.\n", progname);
+	}
 	exit(code);
 }
 
 __attribute__ ((noreturn)) static void
 show_version()
 {
-        fprintf(stderr, "%s: %s\n\n%s\n",progname, VERSION,
+        printf("%s: %s\n\n%s\n", progname, VERSION,
 		"Homepage: https://github.com/docker/hyperkit\n"
 		"License: BSD\n");
-		exit(0);
+	exit(0);
 }
 
 void

--- a/src/include/xhyve/log.h
+++ b/src/include/xhyve/log.h
@@ -1,7 +1,19 @@
 #pragma once
 
-/* Initialize ASL logger and local buffer. */
+/* Initialize logger. */
 void log_init(void);
 
-/* Send one character to the logger: wait for full lines before actually sending. */
-void log_put(uint8_t _c);
+/* Send one character to the console logger. */
+void log_console_put(char _c);
+
+/* Specify where logs should be sent: `stderr` or `log`.  Dies on error.  */
+void log_set_destination(const char* dst);
+
+/* If logging is enabled, intercept outputs to stdout/stderr to the
+ * logger, otherwise forward to fprintf. */
+__attribute__ ((format (printf, 2, 3)))
+int log_fprintf(FILE* f, const char *fmt, ...);
+
+/* Intercept all the calls to fprintf to honor log_set_destination.  */
+#define fprintf log_fprintf
+#define printf(...) log_fprintf(stdout, __VA_ARGS__)

--- a/src/include/xhyve/xhyve.h
+++ b/src/include/xhyve/xhyve.h
@@ -78,3 +78,5 @@ void vcpu_add(int fromcpu, int newcpu, uint64_t rip);
 int fbsdrun_vmexit_on_hlt(void);
 int fbsdrun_vmexit_on_pause(void);
 int fbsdrun_virtio_msix(void);
+
+#include <xhyve/log.h>

--- a/src/lib/log.c
+++ b/src/lib/log.c
@@ -1,24 +1,28 @@
 #include <asl.h>
-#include <pwd.h>
 #include <fcntl.h>
+#include <pwd.h>
 #include <stdio.h>
+#include <sysexits.h>
 #include <time.h>
 
 #include <SystemConfiguration/SystemConfiguration.h>
 
 #include <xhyve/log.h>
 
+/* Some functions below invoke functions with non-literal format
+ * strings, and it's ok: their (top-level) fmt string was checked. */
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
+
 static aslclient log_client = NULL;
 static aslmsg log_msg = NULL;
 
-static unsigned char buf[4096];
+static char buf[4096];
 /* Index of the _next_ character to insert in the buffer. */
 static size_t buf_idx = 0;
 
 /* asl is deprecated in favor of os_log starting with macOS 10.12.  */
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 
-/* Initialize ASL logger and local buffer. */
 void log_init(void)
 {
 	log_client = asl_open(NULL, NULL, 0);
@@ -36,7 +40,7 @@ static void log_flush(void)
 
 
 /* Send one character to the logger: wait for full lines before actually sending. */
-void log_put(uint8_t c)
+static void log_put(char c)
 {
 	if ((c == '\n') || (c == 0)) {
 		log_flush();
@@ -46,5 +50,98 @@ void log_put(uint8_t c)
 		}
 		buf[buf_idx] = c;
 		++buf_idx;
+	}
+}
+
+
+/* Send a string to the logger: wait for full lines before actually sending. */
+static void log_puts(const char *s)
+{
+	for (; *s; ++s) {
+		log_put(*s);
+	}
+}
+
+
+/* Send a string to the logger: wait for full lines before actually sending. */
+static int log_vprintf(const char *fmt, va_list args)
+{
+	static char buf[4096];
+
+	int res = vsnprintf(buf, sizeof(buf), fmt, args);
+
+	log_puts(buf);
+	return (res);
+}
+
+
+/* Destination for logs.  */
+static enum {
+	LOG_DST_LOG,
+	LOG_DST_STDERR
+}
+log_dst = LOG_DST_STDERR;
+
+void log_set_destination(const char *dst)
+{
+	if (!dst) {
+		log_fprintf(stderr,
+		    "log_set_destination: invalid NULL argument");
+		exit(EX_USAGE);
+	} else if (!strcmp(dst, "log")) {
+		log_dst = LOG_DST_LOG;
+	} else if (!strcmp(dst, "stderr")) {
+		log_dst = LOG_DST_STDERR;
+	} else {
+		log_fprintf(stderr, "log_set_destination: invalid argument: %s",
+		    dst);
+		exit(EX_USAGE);
+	}
+}
+
+
+int log_fprintf(FILE *f, const char *fmt, ...)
+{
+	va_list args;
+	int res = 0;
+
+	va_start(args, fmt);
+	if ((log_dst == LOG_DST_LOG) &&
+	    ((f == stdout) || (f == stderr))) {
+		res = log_vprintf(fmt, args);
+	} else {
+		res = vfprintf(f, fmt, args);
+	}
+	va_end(args);
+	return (res);
+}
+
+
+/* A buffer for the console.  */
+static char console_buf[4096];
+/* Index of the _next_ character to insert in console_buf. */
+static size_t console_idx = 0;
+
+
+/* Send the content of the buffer to the logger. */
+static void log_console_flush(void)
+{
+	console_buf[console_idx] = 0;
+	log_fprintf(stderr, "%s\n", console_buf);
+	console_idx = 0;
+}
+
+
+/* Send one character to the logger: wait for full lines before actually sending. */
+void log_console_put(char c)
+{
+	if ((c == '\n') || (c == 0)) {
+		log_console_flush();
+	} else {
+		if (console_idx + 2 >= sizeof(console_buf)) {
+			log_console_flush();
+		}
+		console_buf[console_idx] = c;
+		++console_idx;
 	}
 }

--- a/src/lib/uart_emul.c
+++ b/src/lib/uart_emul.c
@@ -439,7 +439,7 @@ uart_write(struct uart_softc *sc, int offset, uint8_t value)
 			if (sc->log.ring)
 				ringwrite(&sc->log, value);
 			if (sc->asl)
-				log_put(value);
+				log_console_put((char)value);
 		} /* else drop on floor */
 		sc->thre_int_pending = true;
 		break;


### PR DESCRIPTION
Currently in Docker for Mac, the various backend tools use the system logger, which is extremely convenient to use, both from the CLI or from its GUI (Console.app).  However, some of the log messages from hyperkit are still just sent to stdout/stderr, and they then appear credited to the parent process (com.docker.driver).  For instance:

```
2018-05-11 11:30:31.930181 +0200	par défaut	60743	com.docker.hyperkit	[  287.446631] reboot: Power down
2018-05-11 11:30:31.933951 +0200	par défaut	60740	com.docker.driver.amd64-linux	hyperkit: stdout: virtio-net-vpnkit: initialising, opts="path=vpnkit.eth.sock,uuid=d0460c75-ebae-4c39-bc51-83914bbc93b6"
2018-05-11 11:30:31.934027 +0200	par défaut	60740	com.docker.driver.amd64-linux	hyperkit: stdout: virtio-net-vpnkit: interface will have uuid d0460c75-ebae-4c39-bc51-83914bbc93b6
2018-05-11 11:30:31.934062 +0200	par défaut	60740	com.docker.driver.amd64-linux	hyperkit: stdout: virtio-net-vpnkit: Connection established with MAC=02:50:00:00:00:01 and MTU 1500
2018-05-11 11:30:31.934118 +0200	par défaut	60740	com.docker.driver.amd64-linux	hyperkit: stdout: virtio-9p: initialising path=vpnkit.port.sock,tag=port
2018-05-11 11:30:31.934178 +0200	par défaut	60740	com.docker.driver.amd64-linux	hyperkit: stdout: linkname vms/0/tty
2018-05-11 11:30:31.934241 +0200	par défaut	60740	com.docker.driver.amd64-linux	hyperkit: stdout: COM1 connected to /dev/ttys004
2018-05-11 11:30:31.934287 +0200	par défaut	60740	com.docker.driver.amd64-linux	hyperkit: stdout: COM1 linked to vms/0/tty
2018-05-11 11:30:32.008685 +0200	par défaut	60740	com.docker.driver.amd64-linux	hyperkit: failed to read stderr: EOF
2018-05-11 11:30:32.008809 +0200	par défaut	60740	com.docker.driver.amd64-linux	hyperkit: failed to read stdout: EOF
2018-05-11 11:30:33.374676 +0200	par défaut	60843	com.docker.driver.amd64-linux	hyperkit: stderr: virtio-net-vpnkit: magic=VMN3T version=22 commit=0123456789012345678901234567890123456789\^B
2018-05-11 11:30:33.375147 +0200	par défaut	60843	com.docker.driver.amd64-linux	hyperkit: stderr: vsock init 3:0 = vms/0, guest_cid = 00000003
2018-05-11 11:30:36.358223 +0200	par défaut	60846	com.docker.hyperkit	\^[[2J\^[[01;01H\^[[=3h\^[[2J\^[[01;01H\^[[2J\^[[01;01H\^[[=3h\^[[2J\^[[01;01H\^[[2J\^[[01;01H\^[[=3h\^[[2J\^[[01;01H\^[[2J\^[[01;01H\^[[=3h\^[[2J\^[[01;01H\^[[2J\^[[01;01H\^[[=3h\^[[2J\^[[01;01H\^[[0m\^[[39m\^[[49m\^[[2J\^[[01;01H\^[[=3h\^[[2J\^[[01;01H\^[[0m\^[[39m\^[[49m\^[[2J\^[[01;01H\^[[0m\^[[39m\^[[49mWelcome to GRUB!
2018-05-11 11:30:36.358543 +0200	par défaut	60846	com.docker.hyperkit	
2018-05-11 11:30:36.366057 +0200	par défaut	60846	com.docker.hyperkit	
\^[[0m\^[[39m\^[[49m\^[[0m\^[[39m\^[[49m\^[[2J\^[[01;01H\^[[0m\^[[39m\^[[49m  Booting `LinuxKit ISO Image'
2018-05-11 11:30:36.366112 +0200	par défaut	60846	com.docker.hyperkit	
2018-05-11 11:30:36.588090 +0200	par défaut	60846	com.docker.hyperkit	
[    0.000000] Linux version 4.9.87-linuxkit-aufs (root@70f48253c8b4) (gcc version 6.4.0 (Alpine 6.4.0) ) #1 SMP Fri Mar 16 18:16:33 UTC 2018
2018-05-11 11:30:36.589129 +0200	par défaut	60846	com.docker.hyperkit	[    0.000000] Command line: BOOT_IMAGE=/boot/kernel console=ttyS0 page_poison=1 vsyscall=emulate panic=1 root=/dev/sr0 text
2018-05-11 11:30:36.589856 +0200	par défaut	60846	com.docker.hyperkit	[    0.000000] x86/fpu: Supporting XSAVE feature 0x001: 'x87 floating point registers'
2018-05-11 11:30:36.590459 +0200	par défaut	60846	com.docker.hyperkit	[    0.000000] x86/fpu: Supporting XSAVE feature 0x002: 'SSE registers'
...
2018-05-11 11:30:37.737567 +0200	par défaut	60846	com.docker.hyperkit	[    1.104987] NET: Registered protocol family 1
2018-05-11 11:30:37.738268 +0200	par défaut	60846	com.docker.hyperkit	[    1.105549] pci 0000:00:1f.0: Activating ISA DMA hang workarounds
2018-05-11 11:30:37.738530 +0200	par défaut	60843	com.docker.driver.amd64-linux	hyperkit: stderr: 
rdmsr to register 0x64e on vcpu 0
2018-05-11 11:30:37.738592 +0200	par défaut	60843	com.docker.driver.amd64-linux	hyperkit: stderr: rdmsr to register 0x34 on vcpu 0
2018-05-11 11:30:37.739582 +0200	par défaut	60846	com.docker.hyperkit	[    1.106691] RAPL PMU: API unit is 2^-32 Joules, 5 fixed counters, 163840 ms ovfl timer
```
All these logs are now credited to hyperkit (without the clutter of the `hyperkit: stdout:` prefixes).

To this end, these commits:
- enforce some consistency in the use of stdout/stderr
- offer a CLI option to decide whether we stick to stderr, or use the system logger
- offer a Go option to this CLI option

This PR has a peer in Docker for Mac: https://github.com/docker/pinata/pull/9309.