### PR TITLE
go: strip the possible options before checking if the image exists

### DIFF
--- a/go/hyperkit.go
+++ b/go/hyperkit.go
@@ -211,6 +211,10 @@ func (h *HyperKit) check() error {
 		}
 	}
 	for _, image := range h.ISOImages {
+		// Strip possible options.
+		if end := strings.LastIndexByte(image, ','); end != -1 {
+			image = image[0:end]
+		}
 		if _, err = os.Stat(image); os.IsNotExist(err) {
 			return fmt.Errorf("ISO %s does not exist", image)
 		}


### PR DESCRIPTION
If passed "foo.iso,ro", we fail with "foo.iso,ro does not exist".

But maybe we should always set ",ro" for ISOs?