### PR TITLE
Don't lock RO block device backing files and open ISOs as RO

### DIFF
--- a/src/lib/block_if.c
+++ b/src/lib/block_if.c
@@ -712,9 +712,11 @@ blockif_open(const char *optstr, const char *ident)
 		}
 		/* Lock the file to prevent concurrent write+write or read+write as this
 		   would usually lead to corruption */
-		if (flock(fd, LOCK_NB | (ro ? LOCK_SH : LOCK_EX)) < 0) {
-			perror("Could not lock backing file");
-			goto err;
+		if (!ro) {
+			if (flock(fd, LOCK_NB | (ro ? LOCK_SH : LOCK_EX)) < 0) {
+				perror("Could not lock backing file");
+				goto err;
+			}
 		}
 		if (fstat(fd, &sbuf) < 0) {
 			perror("Could not stat backing file");

--- a/src/lib/pci_ahci.c
+++ b/src/lib/pci_ahci.c
@@ -2402,7 +2402,17 @@ pci_ahci_hd_init(struct pci_devinst *pi, char *opts)
 static int
 pci_ahci_atapi_init(struct pci_devinst *pi, char *opts)
 {
-	return (pci_ahci_init(pi, opts, 1));
+	char nopts[MAXPATHLEN + 3];
+	int ret;
+
+	/* atapi is only used for CDROMs. Add 'ro' to the options. */
+	ret = snprintf(nopts, sizeof(nopts), "%s,ro", opts);
+	if (ret < 0) {
+		WPRINTF("Path to ISO too long (%d)\n", ret);
+		return (ret);
+	}
+	
+	return (pci_ahci_init(pi, nopts, 1));
 }
 
 /*


### PR DESCRIPTION
This PR contains two small related changes.

The first commit makes sure that HyperKit does not take an advisory exclusive lock on a block device's backing file if `,ro` is passed as an option. The exclusive lock was added with https://github.com/moby/hyperkit/pull/173 to prevent disk corruption when more than one HyperKit process is trying to use the same backing file. For read-only backing files this is not necessary.

The second change adds `,ro` to the options if a `ahci-cd` device is specified. CD devices (ie ISO files) are read-only by definition so we might as well open them read-only (and don't take an exclusive lock).

Together these two changes enable multiple HyperKit instances to share the same ISO file.

I'm not entirely sure if I like adding `,ro` to the `ahci-cd` options. We could simply ask the user to specify `-s 3,ahci-cd,<path to iso>,ro` for ISO images, but that seems tedious as ISOs are read-only. Defaulting `ahci-cd` devices to read-only in different ways would require more invasive changes, such as changing `blockif_open()`.