### PR TITLE
Open ISO images (ahci-cd backing files) as read-only

### DIFF
--- a/src/include/xhyve/block_if.h
+++ b/src/include/xhyve/block_if.h
@@ -50,7 +50,7 @@ struct blockif_req {
 };
 
 struct blockif_ctxt;
-struct blockif_ctxt *blockif_open(const char *optstr, const char *ident);
+struct blockif_ctxt *blockif_open(const char *optstr, const char *ident, int ro);
 off_t blockif_size(struct blockif_ctxt *bc);
 void blockif_chs(struct blockif_ctxt *bc, uint16_t *c, uint8_t *h, uint8_t *s);
 int blockif_sectsz(struct blockif_ctxt *bc);

--- a/src/lib/block_if.c
+++ b/src/lib/block_if.c
@@ -603,7 +603,7 @@ blockif_init(void)
 }
 
 struct blockif_ctxt *
-blockif_open(const char *optstr, const char *ident)
+blockif_open(const char *optstr, const char *ident, int ro)
 {
 	// char name[MAXPATHLEN];
 	char *nopt, *xopts, *cp;
@@ -615,7 +615,7 @@ blockif_open(const char *optstr, const char *ident)
 	int extra, fd, i, sectsz;
 	size_t delete_alignment;
 	void *delete_zero_buf;
-	int nocache, sync, ro, candelete, geom, ssopt, pssopt;
+	int nocache, sync, candelete, geom, ssopt, pssopt;
 	mirage_block_handle mbh;
 	int use_mirage = 0;
 
@@ -632,7 +632,6 @@ blockif_open(const char *optstr, const char *ident)
 	ssopt = 0;
 	nocache = 0;
 	sync = 0;
-	ro = 0;
 
 	pssopt = 0;
 

--- a/src/lib/pci_ahci.c
+++ b/src/lib/pci_ahci.c
@@ -2328,7 +2328,8 @@ pci_ahci_init(struct pci_devinst *pi, char *opts, int atapi)
 	 * slot/func for the identifier string.
 	 */
 	snprintf(bident, sizeof(bident), "%d:%d", pi->pi_slot, pi->pi_func);
-	bctxt = blockif_open(opts, bident);
+	/* ATAPI devices are only used for CDs, assume its a synonym for read-only */
+	bctxt = blockif_open(opts, bident, atapi);
 	if (bctxt == NULL) {
 		ret = 1;
 		goto open_fail;

--- a/src/lib/pci_virtio_block.c
+++ b/src/lib/pci_virtio_block.c
@@ -318,7 +318,7 @@ pci_vtblk_init(struct pci_devinst *pi, char *opts)
 	 * The supplied backing file has to exist
 	 */
 	snprintf(bident, sizeof(bident), "%d:%d", pi->pi_slot, pi->pi_func);
-	bctxt = blockif_open(opts, bident);
+	bctxt = blockif_open(opts, bident, 0);
 	if (bctxt == NULL) {
 		perror("Could not open backing file");
 		return (1);


### PR DESCRIPTION
Commit 6e72b75 ("Lock the backing file to prevent concurrent
modification") added locking to block device backing files. It
uses a shared lock for read-only devices (',ro' option) and an
exclusive lock by default.

The ahci-cd device only supports read-only ISOs as backing file
so it is cumbersome having to specify ',ro' as option in order
to share the same ISO between different HyperKit instances.

This commit adds a 'ro' argument to 'blockif_open()' and only
sets it for ahci-cd devices. This then causes the ISO backing
file to opened with 'O_RDONLY' and a shared lock being taken.
There should be no change for other block devices.

Signed-off-by: Rolf Neugebauer <rolf.neugebauer@docker.com>