### PR TITLE
Log the error if hv_vm_create fails

### DIFF
--- a/src/lib/vmm/intel/vmx.c
+++ b/src/lib/vmm/intel/vmx.c
@@ -471,14 +471,28 @@ static int
 vmx_init(void)
 {
 	int error = hv_vm_create(HV_VM_DEFAULT);
-	if (error) {
-		if (error == HV_NO_DEVICE) {
+	switch (error) {
+		case HV_SUCCESS:
+			break;
+		case HV_NO_DEVICE:
 			printf("vmx_init: processor not supported by "
 			       "Hypervisor.framework\n");
 			return (error);
-		}
-		else
-			xhyve_abort("hv_vm_create failed\n");
+		case HV_BAD_ARGUMENT:
+			/* Should never happen, report to Apple */
+			xhyve_abort("hv_vm_create HV_BAD_ARGUMENT\n");
+		case HV_BUSY:
+			/* Should never happen, report to us (perhaps we need to retry) */
+			xhyve_abort("hv_vm_create HV_BUSY\n");
+		case HV_NO_RESOURCES:
+			/* Don't know if this can happen, report to us */
+			xhyve_abort("hv_vm_create HV_NO_RESOURCES\n");
+		case HV_UNSUPPORTED:
+			/* Don't know if this can happen, report to us */
+			xhyve_abort("hv_vm_create HV_UNSUPPORTED\n");
+		default:
+			/* Should never happen, report to Apple */
+			xhyve_abort("hv_vm_create unknown error %d\n", error);
 	}
 
 	/* Check support for primary processor-based VM-execution controls */


### PR DESCRIPTION
hv_vm_create may fail with

- HV_BAD_ARGUMENT
- HV_BUSY
- HV_NO_DEVICE
- HV_NO_RESOURCES
- HV_UNSUPPORTED

While we already handled `HV_NO_DEVICE` carefully, for the rest we would abort with `hv_vm_create failed` which isn't very helpful. This patch adds a `printf` of the error code so we can investigate a little more (see for example [docker/for-mac#3015])

Signed-off-by: David Scott <dave.scott@docker.com>