### PR TITLE
ocaml: be compatible with -safe-string

### DIFF
--- a/src/lib/mirage_block_ocaml.ml
+++ b/src/lib/mirage_block_ocaml.ml
@@ -124,7 +124,7 @@ module Protocol = struct
       (fun () ->
         in_flight_requests := t :: !in_flight_requests;
       );
-    let n = Unix.write request_writer "X" 0 1 in
+    let n = Unix.write request_writer (Bytes.unsafe_of_string "X") 0 1 in
     if n = 0 then begin
       Printf.fprintf stderr "Got EOF while writing signal to the pipe\n%!";
       exit 1;
@@ -413,7 +413,7 @@ let process_one t =
 (* An Lwt thread which receives the signals from the pipe, grabs the in-flight
    requests and forks background threads to process all the requests. *)
 let serve_forever () =
-  let buf = String.make 1 '\000' in
+  let buf = Bytes.make 1 '\000' in
   let request_reader = Lwt_unix.of_unix_file_descr Protocol.request_reader in
 
   let rec loop () =


### PR DESCRIPTION
In newer versions of OCaml (4.06 and later) `-safe-string` is on by default which means there is a difference between the `string` and `bytes` types where `string` is immutable but `bytes` is mutable.

The expression `Bytes.unsafe_of_string "X"` returns a mutable reference to the constant buffer "X" but the `Unix.write` call will not write to it.

Signed-off-by: David Scott <dave.scott@docker.com>