### PR TITLE
opam: use --disable-sandboxing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,7 @@ jobs:
       - run: brew upgrade python
       - run: brew install opam
       - run: opam init --disable-sandboxing -v -n --comp="${OPAM_COMP}" --switch="${OPAM_COMP}" local "${OPAM_REPO}"
+      - run: opam install depext -y
       - run: opam config exec -- opam depext -i hyperkit
       - run: opam config exec -- make clean
       - run: opam config exec -- make all

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
       # until the base image is updated.
       - run: brew upgrade python
       - run: brew install opam
-      - run: opam init -v -n --comp="${OPAM_COMP}" --switch="${OPAM_COMP}" local "${OPAM_REPO}"
+      - run: opam init --disable-sandboxing -v -n --comp="${OPAM_COMP}" --switch="${OPAM_COMP}" local "${OPAM_REPO}"
       - run: opam config exec -- opam depext -i hyperkit
       - run: opam config exec -- make clean
       - run: opam config exec -- make all


### PR DESCRIPTION
In the CircleCI environment we see failures like
```
+ /Users/distiller/.opam/opam-init/hooks/sandbox.sh "build" "mkdir" "-p" "/Users/distiller/.opam/4.03.0/lib/ocaml/" (CWD=/Users/distiller/.opam/4.03.0/.opam-switch/build/ocaml-base-compiler.4.03.0)
- mkdir: /Users/distiller/.opam/4.03.0/lib/ocaml/: Operation not permitted
[ERROR] The compilation of ocaml-base-compiler failed at
        "/Users/distiller/.opam/opam-init/hooks/sandbox.sh build mkdir -p
        /Users/distiller/.opam/4.03.0/lib/ocaml/".
```
This patch attempts to work around these by disabling the new sandboxing
features of `opam`.

Signed-off-by: David Scott <dave.scott@docker.com>