### PR TITLE
Fix invalid-guest-state entry by updating state when CR0.PG cleared.

### DIFF
--- a/src/lib/vmm/intel/vmx.c
+++ b/src/lib/vmm/intel/vmx.c
@@ -1206,7 +1206,7 @@ vmx_set_guest_reg(int vcpu, int ident, uint64_t regval)
 static int
 vmx_emulate_cr0_access(UNUSED struct vm *vm, int vcpu, uint64_t exitqual)
 {
-	uint64_t crval, regval;
+	uint64_t crval, efer, entryctls, regval;
 	// *pt;
 
 	/* We only handle mov to %cr0 at this time */
@@ -1223,15 +1223,14 @@ vmx_emulate_cr0_access(UNUSED struct vm *vm, int vcpu, uint64_t exitqual)
 	// 	regval, cr0_ones_mask, cr0_zeros_mask, crval);
 	vmcs_write(vcpu, VMCS_GUEST_CR0, crval);
 
-	if (regval & CR0_PG) {
-		uint64_t efer, entryctls;
+	efer = vmcs_read(vcpu, VMCS_GUEST_IA32_EFER);
 
+	if (regval & CR0_PG) {
 		/*
 		 * If CR0.PG is 1 and EFER.LME is 1 then EFER.LMA and
 		 * the "IA-32e mode guest" bit in VM-entry control must be
 		 * equal.
 		 */
-		efer = vmcs_read(vcpu, VMCS_GUEST_IA32_EFER);
 		if (efer & EFER_LME) {
 			efer |= EFER_LMA;
 			vmcs_write(vcpu, VMCS_GUEST_IA32_EFER, efer);
@@ -1252,6 +1251,18 @@ vmx_emulate_cr0_access(UNUSED struct vm *vm, int vcpu, uint64_t exitqual)
 		// 	vmcs_write(vcpu, VMCS_GUEST_PDPTE2, pt[2]);
 		// 	vmcs_write(vcpu, VMCS_GUEST_PDPTE3, pt[3]);
 		// }
+	} else {
+		/*
+		 * If CR0.PG is 0 and EFER.LMA is 1, this is a
+		 * switch out of IA32e mode so emulate that.
+		 */
+		if (efer & EFER_LMA) {
+			efer &= ~(uint64_t)EFER_LMA;
+			vmcs_write(vcpu, VMCS_GUEST_IA32_EFER, efer);
+			entryctls = vmcs_read(vcpu, VMCS_ENTRY_CTLS);
+			entryctls &= ~VM_ENTRY_GUEST_LMA;
+			vmcs_write(vcpu, VMCS_ENTRY_CTLS, entryctls);
+		}
 	}
 
 	return (HANDLED);


### PR DESCRIPTION
["cherry picked" from https://github.com/machyve/xhyve/commit/cc672d5363766e7c2bf10e02ca12efbeda74c487]

Recent Linux kernels (late 4.17) disable paging temporarily
when in long-mode. Handle this case by updating guest and VM
state to make sure they are in sync: EFER.LMA is cleared,
and the 'IA-32e mode guest' entry control is set to 0.

This is effectively the reverse operation to the existing case
when CR0.PG is set.

Signed-off-by: Rolf Neugebauer <rn@rneugeba.io>

Thanks to @grehan-freebsd for the pointer. This lets me boot a 4.19.7 kernel without issue.
resolves #226 