### PR TITLE
ocaml: install opam 1 explicitly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,8 @@ jobs:
       # Manually upgrading the python bottle allows us to avoid this
       # until the base image is updated.
       - run: brew upgrade python
-      - run: brew install opam
+      # Install opam 1 until we become opam 2 compatible
+      - run: brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/72ce8812eaa33abe23533dfa021b51351a6b9c3e/Formula/opam.rb
       - run: opam init -v -n --comp="${OPAM_COMP}" --switch="${OPAM_COMP}" local "${OPAM_REPO}"
       - run: opam config exec -- opam depext -i hyperkit
       - run: opam config exec -- make clean


### PR DESCRIPTION
The current homebrew default is opam 2. We should upgrade to opam 2
but this temporary workaround will unblock other PRs.

Signed-off-by: David Scott <dave.scott@docker.com>