### PR TITLE
README update: opam install qcow.0.10.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ via `brew` and using `opam` to install the appropriate libraries:
     $ brew install opam libev
     $ opam init
     $ eval `opam config env`
-    $ opam install uri qcow.0.10.3 conduit.1.0.0 lwt.3.1.0 qcow-tool mirage-block-unix.2.9.0 conf-libev logs fmt mirage-unix prometheus-app
+    $ opam install uri qcow.0.10.4 conduit.1.0.0 lwt.3.1.0 qcow-tool mirage-block-unix.2.9.0 conf-libev logs fmt mirage-unix prometheus-app
 
 Notes:
 


### PR DESCRIPTION
trying to install qcow.0.10.3 yields a dependency problem:

> The following dependencies couldn't be met:
>   - qcow-tool → qcow >= 0.10.4
>   - qcow-tool → sha = 1.9 → ocaml < 4.06.0
>       base of this switch (use `--unlock-base' to force)
> Your request can't be satisfied:
>   - No available version of qcow satisfies the constraints
> 
> No solution found, exiting

But qcow.0.10.4 works