### PR TITLE
Resolve implicit conversion error on latest MacOS Mojave with latest Xcode

### DIFF
--- a/src/include/xhyve/firmware/fbsd.h
+++ b/src/include/xhyve/firmware/fbsd.h
@@ -66,7 +66,7 @@ struct loader_callbacks {
 	/* Set a guest register value */
 	void (*setreg)(void *arg, int, uint64_t);
 	/* Set a guest MSR value */
-	void (*setmsr)(void *arg, int, uint64_t);
+	void (*setmsr)(void *arg, u_int, uint64_t);
 	/* Set a guest CR value */
 	void (*setcr)(void *arg, int, uint64_t);
 	/* Set the guest GDT address */

--- a/src/lib/firmware/fbsd.c
+++ b/src/lib/firmware/fbsd.c
@@ -679,7 +679,7 @@ cb_setreg(UNUSED void *arg, int r, uint64_t v)
 }
 
 static void
-cb_setmsr(UNUSED void *arg, int r, uint64_t v)
+cb_setmsr(UNUSED void *arg, u_int r, uint64_t v)
 {
 	int error;
 	enum vm_reg_name vmreg;


### PR DESCRIPTION
This change pulls in the update made by jeremyhu in the upstream xhyve project with commit 9ea6650d3766c897ef85a3df15fdd9abcc9ee858 and resolves all implicit conversion errors reported in MacOS Mojave 10.14.4 with LLVM 10.0.1, as reported in issue #246 