### PR TITLE
circleci: use a patched opam.rb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
       # until the base image is updated.
       - run: brew upgrade python
       # Install opam 1 until we become opam 2 compatible
-      - run: brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/72ce8812eaa33abe23533dfa021b51351a6b9c3e/Formula/opam.rb
+      - run: brew install https://gist.githubusercontent.com/djs55/7a94ee5aeb882ef5399c0485d2affdda/raw/bc04ff96e0082d7ee07642337dbb77c51b93d678/opam.rb
       - run: opam init -v -n --comp="${OPAM_COMP}" --switch="${OPAM_COMP}" local "${OPAM_REPO}"
       - run: opam config exec -- opam depext -i hyperkit
       - run: opam config exec -- make clean

--- a/go/Makefile
+++ b/go/Makefile
@@ -69,7 +69,7 @@ vendor-local:
 
 .PHONY: ci setup
 setup:
-	go get github.com/golang/lint/golint
+	go get golang.org/x/lint/golint
 
 ci: setup build/hyperkitgo build/hyperkitgo_linux build/hyperkitgo.exe test
 	test -z "$$(gofmt -s -l . 2>&1 | grep -v ^vendor/ | tee /dev/stderr)"


### PR DESCRIPTION
The current one gives the following error:

    Error: opam: "cxx11" is not a recognized standard

I cargo culted this change from https://github.com/moby/vpnkit/commit/4bb313b0d76fccc508299133e36c2c015184eec8

Signed-off-by: Ian Campbell <ijc@docker.com>