### PR TITLE
Another attempt to fix signedness warnings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,9 +25,9 @@ jobs:
       - run: make all
       - run: test ! -s build/lib/mirage_block_ocaml.cmi || (echo "qcow libraries have been pre-installed in CI environment" && exit 1)
       - run: make test
-      - run: brew install opam
+      - run: brew install opam libev libffi pkg-config
       - run: opam init -v -n --comp="${OPAM_COMP}" --switch="${OPAM_COMP}" local "${OPAM_REPO}"
-      - run: opam config exec -- opam depext -i hyperkit
+      - run: opam pin add hyperkit .
       - run: opam config exec -- make clean
       - run: opam config exec -- make all
       - run: opam config exec -- make test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     macos:
-      xcode: "9.3.0"
+      xcode: "11.3.1"
     environment:
       # OPAM seems to be quite unhappy without $TERM and Circle doesn't seem to set one.
       TERM: vt100

--- a/config.mk
+++ b/config.mk
@@ -44,7 +44,8 @@ CFLAGS_WARN := \
   -Wno-padded \
   -Wno-reserved-id-macro \
   -Wno-unknown-warning-option \
-  -Wno-unused-macros
+  -Wno-unused-macros \
+  -Wno-switch-enum
 
 CFLAGS_DIAG := \
   -fmessage-length=152 \

--- a/repo/opam-licenses.sh
+++ b/repo/opam-licenses.sh
@@ -18,7 +18,7 @@ fi
 
 for DEP in "$@"; do
   echo "Calculating transitive dependencies required by $DEP"
-  opam list --required-by "$DEP" --recursive | tail -n +2 > "dependency.$DEP.raw"
+  opam list --required-by "$DEP" --recursive | tail -n +3 > "dependency.$DEP.raw"
   awk '{print $1"."$2}' < "dependency.$DEP.raw" > "dependency.$DEP"
   rm "dependency.$DEP.raw"
 done
@@ -28,7 +28,7 @@ rm -f "dependency.*"
 rm -f "*.extracted"
 while read -r PACKAGE; do
   echo "looking for license for ${PACKAGE}"
-  URL=$(opam info --field upstream-url "$PACKAGE")
+  URL=$(opam info --field url.src: "$PACKAGE")
   rm -f "/tmp/opam.out"
   if [ -z "${URL}" ]; then
     echo "$PACKAGE has no source: skipping"

--- a/src/include/xhyve/vmm/vmm.h
+++ b/src/include/xhyve/vmm/vmm.h
@@ -69,16 +69,16 @@ typedef int (*vmi_run_func_t)(void *vmi, int vcpu, register_t rip,
 	void *rendezvous_cookie, void *suspend_cookie);
 typedef void (*vmi_vm_cleanup_func_t)(void *vmi);
 typedef void (*vmi_vcpu_cleanup_func_t)(void *vmi, int vcpu);
-typedef int (*vmi_get_register_t)(void *vmi, int vcpu, int num,
+typedef int (*vmi_get_register_t)(void *vmi, int vcpu, enum vm_reg_name num,
 	uint64_t *retval);
-typedef int (*vmi_set_register_t)(void *vmi, int vcpu, int num,
+typedef int (*vmi_set_register_t)(void *vmi, int vcpu, enum vm_reg_name num,
 	uint64_t val);
-typedef int (*vmi_get_desc_t)(void *vmi, int vcpu, int num,
+typedef int (*vmi_get_desc_t)(void *vmi, int vcpu, enum vm_reg_name num,
 	struct seg_desc *desc);
-typedef int (*vmi_set_desc_t)(void *vmi, int vcpu, int num,
+typedef int (*vmi_set_desc_t)(void *vmi, int vcpu, enum vm_reg_name num,
 	struct seg_desc *desc);
-typedef int (*vmi_get_cap_t)(void *vmi, int vcpu, int num, int *retval);
-typedef int (*vmi_set_cap_t)(void *vmi, int vcpu, int num, int val);
+typedef int (*vmi_get_cap_t)(void *vmi, int vcpu, enum vm_cap_type num, int *retval);
+typedef int (*vmi_set_cap_t)(void *vmi, int vcpu, enum vm_cap_type num, int val);
 typedef struct vlapic * (*vmi_vlapic_init)(void *vmi, int vcpu);
 typedef void (*vmi_vlapic_cleanup)(void *vmi, struct vlapic *vlapic);
 typedef void (*vmi_interrupt)(int vcpu);
@@ -122,11 +122,11 @@ int vm_gpabase2memseg(struct vm *vm, uint64_t gpabase,
 int vm_get_memobj(struct vm *vm, uint64_t gpa, size_t len, uint64_t *offset,
 	void **object);
 bool vm_mem_allocated(struct vm *vm, uint64_t gpa);
-int vm_get_register(struct vm *vm, int vcpu, int reg, uint64_t *retval);
-int vm_set_register(struct vm *vm, int vcpu, int reg, uint64_t val);
-int vm_get_seg_desc(struct vm *vm, int vcpu, int reg,
+int vm_get_register(struct vm *vm, int vcpu, enum vm_reg_name reg, uint64_t *retval);
+int vm_set_register(struct vm *vm, int vcpu, enum vm_reg_name reg, uint64_t val);
+int vm_get_seg_desc(struct vm *vm, int vcpu, enum vm_reg_name reg,
 	struct seg_desc *ret_desc);
-int vm_set_seg_desc(struct vm *vm, int vcpu, int reg, struct seg_desc *desc);
+int vm_set_seg_desc(struct vm *vm, int vcpu, enum vm_reg_name reg, struct seg_desc *desc);
 int vm_run(struct vm *vm, int vcpu, struct vm_exit *vm_exit);
 int vm_suspend(struct vm *vm, enum vm_suspend_how how);
 int vm_inject_nmi(struct vm *vm, int vcpu);
@@ -138,8 +138,8 @@ void vm_extint_clear(struct vm *vm, int vcpuid);
 struct vlapic *vm_lapic(struct vm *vm, int cpu);
 struct vioapic *vm_ioapic(struct vm *vm);
 struct vhpet *vm_hpet(struct vm *vm);
-int vm_get_capability(struct vm *vm, int vcpu, int type, int *val);
-int vm_set_capability(struct vm *vm, int vcpu, int type, int val);
+int vm_get_capability(struct vm *vm, int vcpu, enum vm_cap_type type, int *val);
+int vm_set_capability(struct vm *vm, int vcpu, enum vm_cap_type type, int val);
 int vm_get_x2apic_state(struct vm *vm, int vcpu, enum x2apic_state *state);
 int vm_set_x2apic_state(struct vm *vm, int vcpu, enum x2apic_state state);
 int vm_apicid2vcpuid(struct vm *vm, int apicid);

--- a/src/include/xhyve/vmm/vmm_api.h
+++ b/src/include/xhyve/vmm/vmm_api.h
@@ -60,13 +60,13 @@ void xh_vm_set_lowmem_limit(uint32_t limit);
 void xh_vm_set_memflags(int flags);
 size_t xh_vm_get_lowmem_size(void);
 size_t xh_vm_get_highmem_size(void);
-int xh_vm_set_desc(int vcpu, int reg, uint64_t base, uint32_t limit,
+int xh_vm_set_desc(int vcpu, enum vm_reg_name reg, uint64_t base, uint32_t limit,
 	uint32_t access);
-int xh_vm_get_desc(int vcpu, int reg, uint64_t *base, uint32_t *limit,
+int xh_vm_get_desc(int vcpu, enum vm_reg_name reg, uint64_t *base, uint32_t *limit,
 	uint32_t *access);
-int xh_vm_get_seg_desc(int vcpu, int reg, struct seg_desc *seg_desc);
-int xh_vm_set_register(int vcpu, int reg, uint64_t val);
-int xh_vm_get_register(int vcpu, int reg, uint64_t *retval);
+int xh_vm_get_seg_desc(int vcpu, enum vm_reg_name reg, struct seg_desc *seg_desc);
+int xh_vm_set_register(int vcpu, enum vm_reg_name reg, uint64_t val);
+int xh_vm_get_register(int vcpu, enum vm_reg_name reg, uint64_t *retval);
 int xh_vm_run(int vcpu, struct vm_exit *ret_vmexit);
 int xh_vm_suspend(enum vm_suspend_how how);
 int xh_vm_reinit(void);

--- a/src/include/xhyve/vmm/vmm_common.h
+++ b/src/include/xhyve/vmm/vmm_common.h
@@ -211,8 +211,8 @@ struct vie {
 	uint8_t disp_bytes;
 	uint8_t imm_bytes;
 	uint8_t scale;
-	int base_register; /* VM_REG_GUEST_xyz */
-	int index_register; /* VM_REG_GUEST_xyz */
+	enum vm_reg_name base_register; /* VM_REG_GUEST_xyz */
+	enum vm_reg_name index_register; /* VM_REG_GUEST_xyz */
 	int segment_register; /* VM_REG_GUEST_xyz */
 	int64_t displacement; /* optional addr displacement */
 	int64_t immediate; /* optional immediate operand */

--- a/src/lib/mirage_block_ocaml.ml
+++ b/src/lib/mirage_block_ocaml.ml
@@ -352,6 +352,7 @@ let process_one t =
               >>= function
               | Error `Disconnected -> Lwt.return (Error `Disconnected)
               | Error `Unimplemented -> Lwt.return (Error `Unimplemented)
+              | Error _ -> Lwt.return (Error `Unimplemented)
               | Ok () ->
               let len = List.(fold_left (+) 0 (map Cstruct.len bufs)) in
               return (Response.Read len)
@@ -394,6 +395,7 @@ let process_one t =
               | Error `Disconnected -> Lwt.return (Error `Disconnected)
               | Error `Is_read_only -> Lwt.return (Error `Is_read_only)
               | Error `Unimplemented -> Lwt.return (Error `Unimplemented)
+              | Error _ -> Lwt.return (Error `Unimplemented)
               | Ok () ->
                 return Response.Flush
             end

--- a/src/lib/mirage_block_ocaml.ml
+++ b/src/lib/mirage_block_ocaml.ml
@@ -316,7 +316,7 @@ let process_one t =
         match t.request with
           | Request.Connect (block_config, qcow_config) ->
             let open Lwt.Infix in
-            Block.of_config { block_config with Block.Config.lock = true }
+            Block.of_config block_config
             >>= fun base ->
             Qcow.connect ?config:qcow_config base
             >>= fun block ->

--- a/src/lib/pci_virtio_sock.c
+++ b/src/lib/pci_virtio_sock.c
@@ -337,7 +337,7 @@ struct pci_vtsock_softc {
 /* Protocol stuff */
 
 /* Reserved CIDs */
-#define VMADDR_CID_ANY -1U
+#define VMADDR_CID_ANY (uint64_t) -1U
 //#define VMADDR_CID_HYPERVISOR 0
 //#define VMADDR_CID_RESERVED 1
 #define VMADDR_CID_HOST 2

--- a/src/lib/task_switch.c
+++ b/src/lib/task_switch.c
@@ -91,7 +91,7 @@ CTASSERT(sizeof(struct tss32) == 104);
 #define	TSS_BUSY(type)	(((type) & 0x2) != 0)
 
 static uint64_t
-GETREG(int vcpu, int reg)
+GETREG(int vcpu, enum vm_reg_name reg)
 {
 	uint64_t val;
 	int error;
@@ -102,7 +102,7 @@ GETREG(int vcpu, int reg)
 }
 
 static void
-SETREG(int vcpu, int reg, uint64_t val)
+SETREG(int vcpu, enum vm_reg_name reg, uint64_t val)
 {
 	int error;
 
@@ -168,7 +168,8 @@ desc_table_limit_check(int vcpu, uint16_t sel)
 {
 	uint64_t base;
 	uint32_t limit, access;
-	int error, reg;
+	int error;
+	enum vm_reg_name reg;
 
 	reg = ISLDT(sel) ? VM_REG_GUEST_LDTR : VM_REG_GUEST_GDTR;
 	error = xh_vm_get_desc(vcpu, reg, &base, &limit, &access);
@@ -201,7 +202,8 @@ desc_table_rw(int vcpu, struct vm_guest_paging *paging,
 	struct iovec iov[2];
 	uint64_t base;
 	uint32_t limit, access;
-	int error, reg;
+	int error;
+	enum vm_reg_name reg;
 
 	reg = ISLDT(sel) ? VM_REG_GUEST_LDTR : VM_REG_GUEST_GDTR;
 	error = xh_vm_get_desc(vcpu, reg, &base, &limit, &access);
@@ -300,7 +302,7 @@ CTASSERT(sizeof(struct user_segment_descriptor) == 8);
  * Validate the descriptor 'seg_desc' associated with 'segment'.
  */
 static int
-validate_seg_desc(int vcpu, struct vm_task_switch *ts, int segment,
+validate_seg_desc(int vcpu, struct vm_task_switch *ts, enum vm_reg_name segment,
 	struct seg_desc *seg_desc, int *faultptr)
 {
 	struct vm_guest_paging sup_paging;
@@ -459,7 +461,7 @@ tss32_save(int vcpu, struct vm_task_switch *task_switch,
 }
 
 static void
-update_seg_desc(int vcpu, int reg, struct seg_desc *sd)
+update_seg_desc(int vcpu, enum vm_reg_name reg, struct seg_desc *sd)
 {
 	int error;
 

--- a/src/lib/vmm/intel/vmx.c
+++ b/src/lib/vmm/intel/vmx.c
@@ -145,8 +145,8 @@ static int cap_monitor_trap;
  */
 // #define	APIC_ACCESS_ADDRESS	0xFFFFF000
 
-static int vmx_getdesc(void *arg, int vcpu, int reg, struct seg_desc *desc);
-static int vmx_getreg(void *arg, int vcpu, int reg, uint64_t *retval);
+static int vmx_getdesc(void *arg, int vcpu, enum vm_reg_name reg, struct seg_desc *desc);
+static int vmx_getreg(void *arg, int vcpu, enum vm_reg_name reg, uint64_t *retval);
 
 static __inline uint64_t
 reg_read(int vcpuid, hv_x86_reg_t reg) {
@@ -2309,7 +2309,7 @@ done:
 }
 
 static int
-vmx_shadow_reg(int reg)
+vmx_shadow_reg(enum vm_reg_name reg)
 {
 	int shreg;
 
@@ -2372,7 +2372,7 @@ static const hv_x86_reg_t hvregs[] = {
 };
 
 static int
-vmx_getreg(UNUSED void *arg, int vcpu, int reg, uint64_t *retval)
+vmx_getreg(UNUSED void *arg, int vcpu, enum vm_reg_name reg, uint64_t *retval)
 {
 	hv_x86_reg_t hvreg;
 
@@ -2385,11 +2385,11 @@ vmx_getreg(UNUSED void *arg, int vcpu, int reg, uint64_t *retval)
 		return (0);
 	}
 
-	return (vmcs_getreg(vcpu, reg, retval));
+	return (vmcs_getreg(vcpu, (int) reg, retval));
 }
 
 static int
-vmx_setreg(void *arg, int vcpu, int reg, uint64_t val)
+vmx_setreg(void *arg, int vcpu, enum vm_reg_name reg, uint64_t val)
 {
 	int error, shadow;
 	uint64_t ctls;
@@ -2405,7 +2405,7 @@ vmx_setreg(void *arg, int vcpu, int reg, uint64_t val)
 		return (0);
 	}
 
-	error = vmcs_setreg(vcpu, reg, val);
+	error = vmcs_setreg(vcpu, (int) reg, val);
 
 	if (error == 0) {
 		/*
@@ -2444,19 +2444,19 @@ vmx_setreg(void *arg, int vcpu, int reg, uint64_t val)
 }
 
 static int
-vmx_getdesc(UNUSED void *arg, int vcpu, int reg, struct seg_desc *desc)
+vmx_getdesc(UNUSED void *arg, int vcpu, enum vm_reg_name reg, struct seg_desc *desc)
 {
-	return (vmcs_getdesc(vcpu, reg, desc));
+	return (vmcs_getdesc(vcpu, (int) reg, desc));
 }
 
 static int
-vmx_setdesc(UNUSED void *arg, int vcpu, int reg, struct seg_desc *desc)
+vmx_setdesc(UNUSED void *arg, int vcpu, enum vm_reg_name reg, struct seg_desc *desc)
 {
-	return (vmcs_setdesc(vcpu, reg, desc));
+	return (vmcs_setdesc(vcpu, (int) reg, desc));
 }
 
 static int
-vmx_getcap(void *arg, int vcpu, int type, int *retval)
+vmx_getcap(void *arg, int vcpu, enum vm_cap_type type, int *retval)
 {
 	struct vmx *vmx = arg;
 	int vcap;
@@ -2490,7 +2490,7 @@ vmx_getcap(void *arg, int vcpu, int type, int *retval)
 }
 
 static int
-vmx_setcap(void *arg, int vcpu, int type, int val)
+vmx_setcap(void *arg, int vcpu, enum vm_cap_type type, int val)
 {
 	struct vmx *vmx = arg;
 	uint32_t baseval;

--- a/src/lib/vmm/vmm.c
+++ b/src/lib/vmm/vmm.c
@@ -613,7 +613,7 @@ vm_get_memobj(struct vm *vm, uint64_t gpa, size_t len,
 }
 
 int
-vm_get_register(struct vm *vm, int vcpu, int reg, uint64_t *retval)
+vm_get_register(struct vm *vm, int vcpu, enum vm_reg_name reg, uint64_t *retval)
 {
 
 	if (vcpu < 0 || vcpu >= VM_MAXCPU)
@@ -626,7 +626,7 @@ vm_get_register(struct vm *vm, int vcpu, int reg, uint64_t *retval)
 }
 
 int
-vm_set_register(struct vm *vm, int vcpuid, int reg, uint64_t val)
+vm_set_register(struct vm *vm, int vcpuid, enum vm_reg_name reg, uint64_t val)
 {
 	struct vcpu *vcpu;
 	int error;
@@ -649,7 +649,7 @@ vm_set_register(struct vm *vm, int vcpuid, int reg, uint64_t val)
 }
 
 static bool
-is_descriptor_table(int reg)
+is_descriptor_table(enum vm_reg_name reg)
 {
 	switch (reg) {
 	case VM_REG_GUEST_IDTR:
@@ -661,7 +661,7 @@ is_descriptor_table(int reg)
 }
 
 static bool
-is_segment_register(int reg)
+is_segment_register(enum vm_reg_name reg)
 {
 	switch (reg) {
 	case VM_REG_GUEST_ES:
@@ -679,7 +679,7 @@ is_segment_register(int reg)
 }
 
 int
-vm_get_seg_desc(struct vm *vm, int vcpu, int reg,
+vm_get_seg_desc(struct vm *vm, int vcpu, enum vm_reg_name reg,
 		struct seg_desc *desc)
 {
 	if (vcpu < 0 || vcpu >= VM_MAXCPU)
@@ -692,7 +692,7 @@ vm_get_seg_desc(struct vm *vm, int vcpu, int reg,
 }
 
 int
-vm_set_seg_desc(struct vm *vm, int vcpu, int reg,
+vm_set_seg_desc(struct vm *vm, int vcpu, enum vm_reg_name reg,
 		struct seg_desc *desc)
 {
 	if (vcpu < 0 || vcpu >= VM_MAXCPU)
@@ -1628,24 +1628,24 @@ vm_extint_clear(struct vm *vm, int vcpuid)
 }
 
 int
-vm_get_capability(struct vm *vm, int vcpu, int type, int *retval)
+vm_get_capability(struct vm *vm, int vcpu, enum vm_cap_type type, int *retval)
 {
 	if (vcpu < 0 || vcpu >= VM_MAXCPU)
 		return (EINVAL);
 
-	if (type < 0 || type >= VM_CAP_MAX)
+	if (type >= VM_CAP_MAX)
 		return (EINVAL);
 
 	return (VMGETCAP(vm->cookie, vcpu, type, retval));
 }
 
 int
-vm_set_capability(struct vm *vm, int vcpu, int type, int val)
+vm_set_capability(struct vm *vm, int vcpu, enum vm_cap_type type, int val)
 {
 	if (vcpu < 0 || vcpu >= VM_MAXCPU)
 		return (EINVAL);
 
-	if (type < 0 || type >= VM_CAP_MAX)
+	if (type >= VM_CAP_MAX)
 		return (EINVAL);
 
 	return (VMSETCAP(vm->cookie, vcpu, type, val));

--- a/src/lib/vmm/vmm_api.c
+++ b/src/lib/vmm/vmm_api.c
@@ -267,7 +267,7 @@ xh_vm_get_highmem_size(void)
 }
 
 int
-xh_vm_set_desc(int vcpu, int reg, uint64_t base, uint32_t limit,
+xh_vm_set_desc(int vcpu, enum vm_reg_name reg, uint64_t base, uint32_t limit,
 	uint32_t access)
 {
 	struct seg_desc sd;
@@ -284,7 +284,7 @@ xh_vm_set_desc(int vcpu, int reg, uint64_t base, uint32_t limit,
 }
 
 int
-xh_vm_get_desc(int vcpu, int reg, uint64_t *base, uint32_t *limit,
+xh_vm_get_desc(int vcpu, enum vm_reg_name reg, uint64_t *base, uint32_t *limit,
 	uint32_t *access)
 {
 	struct seg_desc sd;
@@ -303,7 +303,7 @@ xh_vm_get_desc(int vcpu, int reg, uint64_t *base, uint32_t *limit,
 }
 
 int
-xh_vm_get_seg_desc(int vcpu, int reg, struct seg_desc *seg_desc)
+xh_vm_get_seg_desc(int vcpu, enum vm_reg_name reg, struct seg_desc *seg_desc)
 {
 	int error;
 
@@ -314,7 +314,7 @@ xh_vm_get_seg_desc(int vcpu, int reg, struct seg_desc *seg_desc)
 }
 
 int
-xh_vm_set_register(int vcpu, int reg, uint64_t val)
+xh_vm_set_register(int vcpu, enum vm_reg_name reg, uint64_t val)
 {
 	int error;
 
@@ -326,7 +326,7 @@ xh_vm_set_register(int vcpu, int reg, uint64_t val)
 }
 
 int
-xh_vm_get_register(int vcpu, int reg, uint64_t *retval)
+xh_vm_get_register(int vcpu, enum vm_reg_name reg, uint64_t *retval)
 {
 	int error;
 

--- a/test/test_linux.exp
+++ b/test/test_linux.exp
@@ -35,8 +35,8 @@ set status [wait]
 puts "EXIT status:  $status"
 exec sync
 
-exec hdiutil mount -mountpoint ./test-vol ${DISK}s1
-exec cat ./test-vol/test
+exec diskutil mountDisk ${RDISK}s1
+exec cat "/Volumes/NO NAME/test"
 exec hdiutil detach $DISK
 
 puts "\n\nPASS"

--- a/test/test_linux_qcow.exp
+++ b/test/test_linux_qcow.exp
@@ -16,7 +16,7 @@ expect {
 
 set PWD [ exec pwd ]
 
-spawn ../build/hyperkit -A -m 512M -s 0:0,hostbridge -s 31,lpc -l com1,stdio -s 1:0,ahci-hd,file:///$PWD/disk.qcow2,format=qcow -f kexec,$KERNEL,$INITRD,$CMDLINE
+spawn ../build/hyperkit -A -m 512M -s 0:0,hostbridge -s 31,lpc -l com1,stdio -s 1:0,ahci-hd,file://$PWD/disk.qcow2,format=qcow -f kexec,$KERNEL,$INITRD,$CMDLINE
 set pid [exp_pid]
 set timeout 20
 


### PR DESCRIPTION
This is an experiment similar to #261 and #266.

Rather than cast everything to `(int)` I've tried to plumb though the type `enum vm_reg_name` and only cast to `(int)` at the lower level.