### PR TITLE
virtio-blk: implement DISCARD

### DIFF
--- a/go/disk_test.go
+++ b/go/disk_test.go
@@ -69,7 +69,7 @@ func TestRawDiskTrim(t *testing.T) {
 		Size: 1,
 		Trim: true,
 	}
-	checkEqual(t, "ahci-hd,test.raw", disk.AsArgument())
+	checkEqual(t, "virtio-blk,test.raw", disk.AsArgument())
 }
 
 func newDisk(t *testing.T, p string, s int) Disk {


### PR DESCRIPTION
The protocol defines DISCARD in v1.1:

https://docs.oasis-open.org/virtio/virtio/v1.1/cs01/virtio-v1.1-cs01.pdf

In this simple implementation we advertise a maximum of 1 segment per request, which fits the backend API `block_delete(_, offset, length)`. Experimentally Linux 5.4.9 seems to send one request at a time (tested by deleting files and then executing `fstrim`)

Note we only advertise the feature if the backing file itself supports it.

Switching from AHCI `virtio-blk` works around the known deadlock in the AHCI implementation #94

Signed-off-by: David Scott <dave@recoil.org>