### PR TITLE
test: attempt to make CI more robust

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,10 +189,10 @@ test/vmlinuz test/initrd.gz:
 	@cd test; ./tinycore.sh
 
 test: $(TARGET) test/vmlinuz test/initrd.gz
-	@(cd test && ./test_linux.exp)
+	@(cd test && ./retry-infra-failure 5 ./test_linux.exp)
 
 test-qcow: $(TARGET) test/vmlinuz test/initrd.gz
-	@(cd test && ./test_linux_qcow.exp)
+	@(cd test && ./retry-infra-failure 5 ./test_linux_qcow.exp)
 
 
 ## ----------- ##

--- a/test/retry-infra-failure
+++ b/test/retry-infra-failure
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+retries=$1
+command=$2
+
+ret=0
+for((i=0;i<$retries;i++))
+do
+	$command
+	ret=$?
+	# Use exit code 2 to mean infra failure, need to retry.
+	if [ "$ret" != 2 ]; then
+		exit $ret
+	fi
+done
+
+echo "Persistent failure after $retries tries."
+exit $ret

--- a/test/test_linux.exp
+++ b/test/test_linux.exp
@@ -15,6 +15,7 @@ set timeout 20
 
 expect {
   timeout {puts "FAIL boot"; exec kill -9 $pid; exit 1}
+  "Kernel panic - not syncing: IO-APIC + timer doesn't work" {puts "INFRA nested virtualization failed"; exec kill -9 $pid; exit 2}
   "\r\ntc@box:~$ "
 }
 send "sudo mount /dev/sda1 /mnt/sda1\r\n"

--- a/test/test_linux.exp
+++ b/test/test_linux.exp
@@ -2,7 +2,7 @@
 
 set KERNEL "./vmlinuz"
 set INITRD "./initrd.gz"
-set CMDLINE "earlyprintk=serial console=ttyS0"
+set CMDLINE "earlyprintk=serial console=ttyS0 noapic nosmp"
 
 exec rm -f disk.dmg
 exec hdiutil create -megabytes 20 -fs "MS-DOS" disk

--- a/test/test_linux_qcow.exp
+++ b/test/test_linux_qcow.exp
@@ -22,6 +22,7 @@ set timeout 20
 
 expect {
   timeout {puts "FAIL boot"; exec kill -9 $pid; exit 1}
+  "Kernel panic - not syncing: IO-APIC + timer doesn't work" {puts "INFRA nested virtualization failed"; exec kill -9 $pid; exit 2}
   "\r\ntc@box:~$ "
 }
 send "echo 'This is a block device' > /dev/sda\r\n"

--- a/test/test_linux_qcow.exp
+++ b/test/test_linux_qcow.exp
@@ -2,7 +2,7 @@
 
 set KERNEL "./vmlinuz"
 set INITRD "./initrd.gz"
-set CMDLINE "earlyprintk=serial console=ttyS0"
+set CMDLINE "earlyprintk=serial console=ttyS0 noapic nosmp"
 
 spawn qcow-tool create --size 1GiB disk.qcow2
 set pid [exp_pid]

--- a/test/tinycore.sh
+++ b/test/tinycore.sh
@@ -11,8 +11,8 @@ TMP_DIR=$(mktemp -d -t hyperkit)
 INITRD_DIR="${TMP_DIR}"/initrd
 
 echo Downloading tinycore linux
-curl -s -o vmlinuz "${BASE_URL}/8.x/x86/release/distribution_files/vmlinuz64"
-curl -s -o "${TMP_DIR}"/initrd.gz "${BASE_URL}/8.x/x86/release/distribution_files/core.gz"
+curl -s -o vmlinuz "${BASE_URL}/11.x/x86/release/distribution_files/vmlinuz64"
+curl -s -o "${TMP_DIR}"/initrd.gz "${BASE_URL}/11.x/x86/release/distribution_files/core.gz"
 
 mkdir "${INITRD_DIR}"
 ( cd "${INITRD_DIR}"; gzip -dc "${TMP_DIR}"/initrd.gz | sudo cpio -idm )


### PR DESCRIPTION
The CircleCI nested virtualisation often fails with

```
Kernel panic - not syncing: IO-APIC + timer doesn't work!  Boot with apic=debug and send a report.  Then try booting with the 'noapic' option.
```

Let's try booting the test kernels with the `noapic` option.

Signed-off-by: David Scott <dave@recoil.org>