### PR TITLE
README.md: it should be "for Mac" not "For Mac"

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 *HyperKit* is a toolkit for embedding hypervisor capabilities in your application. It includes a complete hypervisor, based on [xhyve](https://github.com/mist64/xhyve)/[bhyve](http://bhyve.org), which is optimized for lightweight virtual machines and container deployment.  It is designed to be interfaced with higher-level components such as the [VPNKit](https://github.com/moby/vpnkit) and [DataKit](https://github.com/moby/datakit).
 
-HyperKit currently only supports macOS using the [Hypervisor.framework](https://developer.apple.com/library/mac/documentation/DriversKernelHardware/Reference/Hypervisor/index.html). It is a core component of Docker Desktop For Mac.
+HyperKit currently only supports macOS using the [Hypervisor.framework](https://developer.apple.com/library/mac/documentation/DriversKernelHardware/Reference/Hypervisor/index.html). It is a core component of Docker Desktop for Mac.
 
 
 ## Requirements


### PR DESCRIPTION
This is a trivial patch designed to trigger the CI since I don't have access to CircleCI to press the rebuild button.

Signed-off-by: David Scott <dave@recoil.org>