### PR TITLE
Improve error message if TRIM/DISCARD isn't supported

### DIFF
--- a/src/lib/block_if.c
+++ b/src/lib/block_if.c
@@ -732,7 +732,7 @@ blockif_open(const char *optstr, const char *ident, int ro)
 				/* Sparse files are supported: enable TRIM */
 				candelete = 1;
 			} else {
-				perror("fcntl(F_PUNCHHOLE) failed: host filesystem does not support sparse files");
+				fprintf(stderr, "%s: fcntl(F_PUNCHHOLE) %s: block device will not support TRIM/DISCARD\n", nopt, strerror(errno));
 				candelete = 0;
 			}
 		}


### PR DESCRIPTION
Previously we didn't log which device doesn't support TRIM. On systems where some disks support TRIM and some don't it's helpful to know which is which.

Previously we would log that it is the host filesystem which doesn't support TRIM. This isn't always the reason -- for example the file could be open read-only, causing our test TRIM to fail.

This patch includes the filename in the log message and simply says that TRIM/DISCARD won't be supported e.g.

```
docker-desktop.iso: fcntl(F_PUNCHHOLE) Operation not permitted: block device will not support TRIM/DISCARD
```

Signed-off-by: David Scott <dave.scott@docker.com>