### PR TITLE
vmx: inherit defaults from hypervisor

### DIFF
--- a/src/lib/vmm/intel/vmx.c
+++ b/src/lib/vmm/intel/vmx.c
@@ -596,6 +596,7 @@ vmx_vcpu_init(void *arg, int vcpuid) {
 	vmx_msr_guest_init(vmx, vcpuid);
 
 	/* Check support for primary processor-based VM-execution controls */
+	procbased_ctls = (uint32_t) vmcs_read(vcpuid, HV_VMX_CAP_PROCBASED);
 	error = vmx_set_ctlreg(HV_VMX_CAP_PROCBASED,
 			       PROCBASED_CTLS_ONE_SETTING,
 			       PROCBASED_CTLS_ZERO_SETTING, &procbased_ctls);
@@ -609,6 +610,7 @@ vmx_vcpu_init(void *arg, int vcpuid) {
 	procbased_ctls &= ~PROCBASED_CTLS_WINDOW_SETTING;
 
 	/* Check support for secondary processor-based VM-execution controls */
+	procbased_ctls2 = (uint32_t) vmcs_read(vcpuid, HV_VMX_CAP_PROCBASED2);
 	error = vmx_set_ctlreg(HV_VMX_CAP_PROCBASED2,
 			       PROCBASED_CTLS2_ONE_SETTING,
 			       PROCBASED_CTLS2_ZERO_SETTING, &procbased_ctls2);
@@ -619,6 +621,7 @@ vmx_vcpu_init(void *arg, int vcpuid) {
 	}
 
 	/* Check support for pin-based VM-execution controls */
+	pinbased_ctls = (uint32_t) vmcs_read(vcpuid, HV_VMX_CAP_PINBASED);
 	error = vmx_set_ctlreg(HV_VMX_CAP_PINBASED,
 			       PINBASED_CTLS_ONE_SETTING,
 			       PINBASED_CTLS_ZERO_SETTING, &pinbased_ctls);
@@ -629,6 +632,7 @@ vmx_vcpu_init(void *arg, int vcpuid) {
 	}
 
 	/* Check support for VM-exit controls */
+	exit_ctls = (uint32_t) vmcs_read(vcpuid, HV_VMX_CAP_EXIT);
 	error = vmx_set_ctlreg(HV_VMX_CAP_EXIT,
 			       VM_EXIT_CTLS_ONE_SETTING,
 			       VM_EXIT_CTLS_ZERO_SETTING,
@@ -640,6 +644,7 @@ vmx_vcpu_init(void *arg, int vcpuid) {
 	}
 
 	/* Check support for VM-entry controls */
+	entry_ctls = (uint32_t) vmcs_read(vcpuid, HV_VMX_CAP_ENTRY);
 	error = vmx_set_ctlreg(HV_VMX_CAP_ENTRY,
 	    VM_ENTRY_CTLS_ONE_SETTING, VM_ENTRY_CTLS_ZERO_SETTING,
 	    &entry_ctls);

--- a/src/lib/vmm/intel/vmx.c
+++ b/src/lib/vmm/intel/vmx.c
@@ -496,60 +496,6 @@ vmx_init(void)
 			xhyve_abort("hv_vm_create unknown error %d\n", error);
 	}
 
-	/* Check support for primary processor-based VM-execution controls */
-	error = vmx_set_ctlreg(HV_VMX_CAP_PROCBASED,
-			       PROCBASED_CTLS_ONE_SETTING,
-			       PROCBASED_CTLS_ZERO_SETTING, &procbased_ctls);
-	if (error) {
-		printf("vmx_init: processor does not support desired primary "
-		       "processor-based controls\n");
-		return (error);
-	}
-
-	/* Clear the processor-based ctl bits that are set on demand */
-	procbased_ctls &= ~PROCBASED_CTLS_WINDOW_SETTING;
-
-	/* Check support for secondary processor-based VM-execution controls */
-	error = vmx_set_ctlreg(HV_VMX_CAP_PROCBASED2,
-			       PROCBASED_CTLS2_ONE_SETTING,
-			       PROCBASED_CTLS2_ZERO_SETTING, &procbased_ctls2);
-	if (error) {
-		printf("vmx_init: processor does not support desired secondary "
-		       "processor-based controls\n");
-		return (error);
-	}
-
-	/* Check support for pin-based VM-execution controls */
-	error = vmx_set_ctlreg(HV_VMX_CAP_PINBASED,
-			       PINBASED_CTLS_ONE_SETTING,
-			       PINBASED_CTLS_ZERO_SETTING, &pinbased_ctls);
-	if (error) {
-		printf("vmx_init: processor does not support desired "
-		       "pin-based controls\n");
-		return (error);
-	}
-
-	/* Check support for VM-exit controls */
-	error = vmx_set_ctlreg(HV_VMX_CAP_EXIT,
-			       VM_EXIT_CTLS_ONE_SETTING,
-			       VM_EXIT_CTLS_ZERO_SETTING,
-			       &exit_ctls);
-	if (error) {
-		printf("vmx_init: processor does not support desired "
-		    "exit controls\n");
-		return (error);
-	}
-
-	/* Check support for VM-entry controls */
-	error = vmx_set_ctlreg(HV_VMX_CAP_ENTRY,
-	    VM_ENTRY_CTLS_ONE_SETTING, VM_ENTRY_CTLS_ZERO_SETTING,
-	    &entry_ctls);
-	if (error) {
-		printf("vmx_init: processor does not support desired "
-		    "entry controls\n");
-		return (error);
-	}
-
 	/*
 	 * Check support for optional features by testing them
 	 * as individual bits
@@ -648,6 +594,60 @@ vmx_vcpu_init(void *arg, int vcpuid) {
 	}
 
 	vmx_msr_guest_init(vmx, vcpuid);
+
+	/* Check support for primary processor-based VM-execution controls */
+	error = vmx_set_ctlreg(HV_VMX_CAP_PROCBASED,
+			       PROCBASED_CTLS_ONE_SETTING,
+			       PROCBASED_CTLS_ZERO_SETTING, &procbased_ctls);
+	if (error) {
+		printf("vmx_init: processor does not support desired primary "
+		       "processor-based controls\n");
+		return (error);
+	}
+
+	/* Clear the processor-based ctl bits that are set on demand */
+	procbased_ctls &= ~PROCBASED_CTLS_WINDOW_SETTING;
+
+	/* Check support for secondary processor-based VM-execution controls */
+	error = vmx_set_ctlreg(HV_VMX_CAP_PROCBASED2,
+			       PROCBASED_CTLS2_ONE_SETTING,
+			       PROCBASED_CTLS2_ZERO_SETTING, &procbased_ctls2);
+	if (error) {
+		printf("vmx_init: processor does not support desired secondary "
+		       "processor-based controls\n");
+		return (error);
+	}
+
+	/* Check support for pin-based VM-execution controls */
+	error = vmx_set_ctlreg(HV_VMX_CAP_PINBASED,
+			       PINBASED_CTLS_ONE_SETTING,
+			       PINBASED_CTLS_ZERO_SETTING, &pinbased_ctls);
+	if (error) {
+		printf("vmx_init: processor does not support desired "
+		       "pin-based controls\n");
+		return (error);
+	}
+
+	/* Check support for VM-exit controls */
+	error = vmx_set_ctlreg(HV_VMX_CAP_EXIT,
+			       VM_EXIT_CTLS_ONE_SETTING,
+			       VM_EXIT_CTLS_ZERO_SETTING,
+			       &exit_ctls);
+	if (error) {
+		printf("vmx_init: processor does not support desired "
+		    "exit controls\n");
+		return (error);
+	}
+
+	/* Check support for VM-entry controls */
+	error = vmx_set_ctlreg(HV_VMX_CAP_ENTRY,
+	    VM_ENTRY_CTLS_ONE_SETTING, VM_ENTRY_CTLS_ZERO_SETTING,
+	    &entry_ctls);
+	if (error) {
+		printf("vmx_init: processor does not support desired "
+		    "entry controls\n");
+		return (error);
+	}
 
 	vmcs_write(vcpuid, VMCS_PIN_BASED_CTLS, pinbased_ctls);
 	vmcs_write(vcpuid, VMCS_PRI_PROC_BASED_CTLS, procbased_ctls);

--- a/src/lib/vmm/intel/vmx_msr.c
+++ b/src/lib/vmm/intel/vmx_msr.c
@@ -96,17 +96,17 @@ int vmx_set_ctlreg(hv_vmx_capability_t cap_field, uint32_t ones_mask,
 			}
 			*retval |= 1 << i;
 		} else {
-			/* don't care */
+			/* Hypervisor doesn't care */
 			if (zeros_mask & (1 << i)){
 				*retval &= ~(1 << i);
 			} else if (ones_mask & (1 << i)) {
 				*retval |= 1 << i;
 			} else {
-				/* XXX: don't allow unspecified don't cares */
+				/* We don't care either: inherit the system default */
 				fprintf(stderr,
 					"vmx_set_ctlreg: cap_field: %d bit: %d unspecified "
-					"don't care\n", cap_field, i);
-				return (EINVAL);
+					"don't care: bit is %d\n", cap_field, i,
+					(*retval & (1 << i))?1:0);
 			}
 		}
 	}


### PR DESCRIPTION
There have been some observed initialisation failures on new hypervisors / hardware, caused by us not recognising a new hypervisor feature. Previously the code would print an error and exit if it encountered an unknown feature.

However the hypervisor is able to provide a safe default, so we should use that instead. Setting the features we want is a VMCS write and querying the default fields is a VMCS read.

Therefore this patch
- moves the capability probing into the vCPU setup where a VMCS read is possible
- initialises the feature bits with a VMCS read (previously these were all 0)
- removes the failure case when we encounter an unknown feature bit (since the default will be safe)
