### PR TITLE
tty: write filename in a file, don't symlink to /dev

### DIFF
--- a/src/lib/uart_emul.c
+++ b/src/lib/uart_emul.c
@@ -758,14 +758,16 @@ uart_set_backend(struct uart_softc *sc, const char *backend, const char *devname
 
 			if (linkname) {
 				if ((unlink(linkname) == -1) && (errno != ENOENT)) {
-					perror("unlinking autopty symlink");
+					perror("unlinking autopty file");
 					goto err;
 				}
-				if (symlink(ptyname, linkname) == -1){
-					perror("creating autopty symlink");
+				int namefd = open(linkname, O_CREAT | O_WRONLY);
+				if (namefd == -1) {
+					perror("creating autopty file");
 					goto err;
 				}
-				fprintf(stdout, "%s linked to %s\n", devname, linkname);
+				(void) write(namefd, ptyname, strlen(ptyname));
+				(void) close(namefd);
 			}
 
 			sc->tty.fd = ptyfd;


### PR DESCRIPTION
If the osquery tool[1] is running and scanning a directory containing the `tty` symlink, it will follow the link to `/dev/ttys*` and start some kind of infinite loop involving the debug console. This causes hyperkit's CPU to spike and for the console itself to be spammed with it's own output.

The easiest workaround is to not create the symlink, but write the name of the tty in a file instead. Therefore for debugging we can still run

```
screen $(cat ~/Library/Containers/com.docker.docker/Data/vms/0/tty)
```
(or equivalent)

Reported originally around here[2]

[1] https://osquery.io/downloads/
[2] https://github.com/docker/for-mac/issues/3499#issuecomment-639140844

Signed-off-by: David Scott <dave@recoil.org>