### PR TITLE
fix tty file permissions

### DIFF
--- a/src/lib/uart_emul.c
+++ b/src/lib/uart_emul.c
@@ -761,7 +761,7 @@ uart_set_backend(struct uart_softc *sc, const char *backend, const char *devname
 					perror("unlinking autopty file");
 					goto err;
 				}
-				int namefd = open(linkname, O_CREAT | O_WRONLY);
+				int namefd = open(linkname, O_CREAT | O_WRONLY, 0644);
 				if (namefd == -1) {
 					perror("creating autopty file");
 					goto err;


### PR DESCRIPTION
After installing 2.3.3.0 I was unable to run `cat ~/Library/Containers/com.docker.docker/Data/vms/0/tty` because file permissions were 000. It looks like open() in 4aad16e4e with O_CREAT flag takes three arguments, but only two were provided and that third argument was taken from stack, which resulted in zero permissions on file in my case.