### PR TITLE
go: improve serial console

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,6 @@ go 1.14
 
 require (
 	github.com/mitchellh/go-ps v1.0.0
+	github.com/stretchr/testify v1.6.1
 	golang.org/x/sys v0.0.0-20200722175500-76b94024e4b6
 )

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/moby/hyperkit
+
+go 1.14
+
+require (
+	github.com/mitchellh/go-ps v1.0.0
+	golang.org/x/sys v0.0.0-20200722175500-76b94024e4b6
+)

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,14 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/mitchellh/go-ps v1.0.0 h1:i6ampVEEF4wQFF+bkYfwYgY+F/uYJDktmvLPf7qIgjc=
 github.com/mitchellh/go-ps v1.0.0/go.mod h1:J4lOc8z8yJs6vUwklHw2XEIiT4z4C40KtWVN3nvg8Pg=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 golang.org/x/sys v0.0.0-20200722175500-76b94024e4b6 h1:X9xIZ1YU8bLZA3l6gqDUHSFiD0GFI9S548h6C8nDtOY=
 golang.org/x/sys v0.0.0-20200722175500-76b94024e4b6/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/mitchellh/go-ps v1.0.0 h1:i6ampVEEF4wQFF+bkYfwYgY+F/uYJDktmvLPf7qIgjc=
+github.com/mitchellh/go-ps v1.0.0/go.mod h1:J4lOc8z8yJs6vUwklHw2XEIiT4z4C40KtWVN3nvg8Pg=
+golang.org/x/sys v0.0.0-20200722175500-76b94024e4b6 h1:X9xIZ1YU8bLZA3l6gqDUHSFiD0GFI9S548h6C8nDtOY=
+golang.org/x/sys v0.0.0-20200722175500-76b94024e4b6/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/go/hyperkit_test.go
+++ b/go/hyperkit_test.go
@@ -1,0 +1,31 @@
+package hyperkit
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLegacyConsole(t *testing.T) {
+	h, err := New("hyperkit", "", "state-dir")
+	require.Nil(t, err)
+
+	h.Console = ConsoleFile
+	h.buildArgs("")
+	assert.EqualValues(t, []string{"-A", "-u", "-F", "state-dir/hyperkit.pid", "-c", "1", "-m", "1024M", "-s", "0:0,hostbridge", "-s", "31,lpc", "-s", "1,virtio-rnd", "-l", "com1,autopty=state-dir/tty,log=state-dir/console-ring", "-f", "kexec,,,earlyprintk=serial "}, h.Arguments)
+}
+
+func TestNewSerial(t *testing.T) {
+	h, err := New("hyperkit", "", "state-dir")
+	require.Nil(t, err)
+
+	h.Serials = []Serial{
+		{
+			InteractiveConsole: TTYInteractiveConsole,
+			LogToRingBuffer:    true,
+		},
+	}
+	h.buildArgs("")
+	assert.EqualValues(t, []string{"-A", "-u", "-F", "state-dir/hyperkit.pid", "-c", "1", "-m", "1024M", "-s", "0:0,hostbridge", "-s", "31,lpc", "-s", "1,virtio-rnd", "-l", "com1,autopty=state-dir/tty,log=state-dir/console-ring", "-f", "kexec,,,earlyprintk=serial "}, h.Arguments)
+}

--- a/go/hyperkit_test.go
+++ b/go/hyperkit_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestLegacyConsole(t *testing.T) {
-	h, err := New("hyperkit", "", "state-dir")
+	h, err := New("sh", "", "state-dir")
 	require.Nil(t, err)
 
 	h.Console = ConsoleFile
@@ -17,7 +17,7 @@ func TestLegacyConsole(t *testing.T) {
 }
 
 func TestNewSerial(t *testing.T) {
-	h, err := New("hyperkit", "", "state-dir")
+	h, err := New("sh", "", "state-dir")
 	require.Nil(t, err)
 
 	h.Serials = []Serial{
@@ -27,5 +27,18 @@ func TestNewSerial(t *testing.T) {
 		},
 	}
 	h.buildArgs("")
-	assert.EqualValues(t, []string{"-A", "-u", "-F", "state-dir/hyperkit.pid", "-c", "1", "-m", "1024M", "-s", "0:0,hostbridge", "-s", "31,lpc", "-s", "1,virtio-rnd", "-l", "com1,autopty=state-dir/tty,log=state-dir/console-ring", "-f", "kexec,,,earlyprintk=serial "}, h.Arguments)
+	assert.EqualValues(t, []string{"-A", "-u", "-F", "state-dir/hyperkit.pid", "-c", "1", "-m", "1024M", "-s", "0:0,hostbridge", "-s", "31,lpc", "-s", "1,virtio-rnd", "-l", "com1,autopty=state-dir/tty1,log=state-dir/console-ring", "-f", "kexec,,,earlyprintk=serial "}, h.Arguments)
+}
+
+func TestNullSerial(t *testing.T) {
+	h, err := New("sh", "", "state-dir")
+	require.Nil(t, err)
+
+	h.Serials = []Serial{
+		{
+			LogToRingBuffer: true,
+		},
+	}
+	h.buildArgs("")
+	assert.EqualValues(t, []string{"-A", "-u", "-F", "state-dir/hyperkit.pid", "-c", "1", "-m", "1024M", "-s", "0:0,hostbridge", "-s", "31,lpc", "-s", "1,virtio-rnd", "-l", "com1,null,log=state-dir/console-ring", "-f", "kexec,,,earlyprintk=serial "}, h.Arguments)
 }

--- a/src/lib/uart_emul.c
+++ b/src/lib/uart_emul.c
@@ -722,7 +722,15 @@ uart_set_backend(struct uart_softc *sc, const char *backend, const char *devname
 		if (next)
 			next[0] = '\0';
 
-		if (strcmp("stdio", backend) == 0 && !uart_stdio) {
+		if (strcmp("null", backend) == 0) {
+			sc->tty.fd = open("/dev/null", O_RDWR | O_NONBLOCK);
+			if (sc->tty.fd == -1) {
+				fprintf(stderr, "error opening /dev/null\n");
+				goto err;
+			}
+			sc->tty.opened = true;
+			retval = 0;
+		} else if (strcmp("stdio", backend) == 0 && !uart_stdio) {
 			sc->tty.fd = STDIN_FILENO;
 			sc->tty.opened = true;
 			uart_stdio = true;


### PR DESCRIPTION
The current Go API for setting up the serial console has limitations, including:
- it supports at most one serial port
- it requires either `stdio` or a `tty`, and will trigger an `assert` if you don't provide one of them
- it combines the request for a `tty` with the request to log the output to a ring-buffer or to Apple System Log.

This PR adds a new Go API while keeping (but deprecating) the old one. It's now possible to have multiple serial ports, each of which is connected to one of:
- `/dev/null`
- a TTY
- `stdio`

and of which can be separately logged to any combination of:
- `/dev/null`
- a ring buffer
- Apple System Log

This PR also adds a `go.mod` and some unit tests for the console-related command-line building functions.