### PR TITLE
Use unix.IoctlSetTermios instead of ioctl system call on darwin

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,5 @@ go 1.14
 require (
 	github.com/mitchellh/go-ps v1.0.0
 	github.com/stretchr/testify v1.6.1
-	golang.org/x/sys v0.0.0-20200722175500-76b94024e4b6
+	golang.org/x/sys v0.0.0-20201015000850-e3ed0017c211
 )

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 golang.org/x/sys v0.0.0-20200722175500-76b94024e4b6 h1:X9xIZ1YU8bLZA3l6gqDUHSFiD0GFI9S548h6C8nDtOY=
 golang.org/x/sys v0.0.0-20200722175500-76b94024e4b6/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201015000850-e3ed0017c211 h1:9UQO31fZ+0aKQOFldThf7BKPMJTiBfWycGh/u3UoO88=
+golang.org/x/sys v0.0.0-20201015000850-e3ed0017c211/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go/pty_util_darwin.go
+++ b/go/pty_util_darwin.go
@@ -7,24 +7,21 @@ which is under Apache License Version 2.0, January 2004
 */
 import (
 	"os"
-	"unsafe"
 
 	"golang.org/x/sys/unix"
 )
 
 func tcget(fd uintptr, p *unix.Termios) error {
-	return ioctl(fd, unix.TIOCGETA, uintptr(unsafe.Pointer(p)))
+	termios, err := unix.IoctlGetTermios(int(fd), unix.TIOCGETA)
+	if err != nil {
+		return err
+	}
+	*p = *termios
+	return nil
 }
 
 func tcset(fd uintptr, p *unix.Termios) error {
-	return ioctl(fd, unix.TIOCSETA, uintptr(unsafe.Pointer(p)))
-}
-
-func ioctl(fd, flag, data uintptr) error {
-	if _, _, err := unix.Syscall(unix.SYS_IOCTL, fd, flag, data); err != 0 {
-		return err
-	}
-	return nil
+	return unix.IoctlSetTermios(int(fd), unix.TIOCSETA, p)
 }
 
 func saneTerminal(f *os.File) error {


### PR DESCRIPTION
This is necessary due to an upgrade in Golang's sys package, which no longer allows for direct system calls on darwin.

Fixes https://github.com/moby/hyperkit/issues/298

This code was copied from https://github.com/containerd/console/blob/2f74731477a5334b870605b261bcfb71ba34c56a/tc_unix.go, which a comment at the top of the file says the old code came from. 