### PR TITLE
build: Add entitlements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,9 +179,11 @@ $(TARGET).sym: $(OBJ)
 	@echo dsym $(notdir $(TARGET).dSYM)
 	$(VERBOSE) $(ENV) $(DSYM) $@ -o $(TARGET).dSYM
 
-$(TARGET): $(TARGET).sym
+$(TARGET): $(TARGET).sym app.entitlements
 	@echo strip $(notdir $@)
 	$(VERBOSE) $(ENV) $(STRIP) $(TARGET).sym -o $@
+	@echo sign $(notdir $@)
+	$(VERBOSE) $(ENV) $(CODESIGN) -s - --entitlements app.entitlements --force $@
 
 clean:
 	@rm -rf build

--- a/app.entitlements
+++ b/app.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.hypervisor</key>
+    <true/>
+</dict>
+</plist>

--- a/config.mk
+++ b/config.mk
@@ -19,6 +19,7 @@ LD := clang
 STRIP := strip
 DSYM := dsymutil
 DTRACE := dtrace
+CODESIGN := codesign
 
 ENV := \
   LANG=en_US.US-ASCII


### PR DESCRIPTION
On Bigsur need to add Hypervisor framework entitlement.

Based on https://stackoverflow.com/questions/64642062/apple-hypervisor-is-completely-broken-on-macos-big-sur-beta-11-0-1
via https://github.com/moby/hyperkit/issues/300#issuecomment-747457675

Signed-off-by: Rolf Neugebauer <rn@rneugeba.io>

fixes #300