### PR TITLE
Embed an Info.plist, with a distinct bundle identifier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ _build
 /test/initrd.gz
 /test/disk.dmg
 /test/disk.qcow2
+Info.plist

--- a/Info.plist.in
+++ b/Info.plist.in
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDisplayName</key>
+	<string>HyperKit</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.moby.hyperkit</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>HyperKit</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>%VERSION%</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>0.0.0</string>
+	<key>LSApplicationCategoryType</key>
+	<string>public.app-category.developer-tools</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>10.11</string>
+</dict>
+</plist>

--- a/Makefile
+++ b/Makefile
@@ -173,9 +173,12 @@ build/%.o: src/%.ml
 	$(VERBOSE) $(ENV) ocamlfind ocamlopt -thread -package "$(OCAML_PACKS)" -c $< -o build/$*.cmx
 	$(VERBOSE) $(ENV) ocamlfind ocamlopt -thread -linkpkg -package "$(OCAML_PACKS)" -output-obj -o $@ build/$*.cmx
 
-$(TARGET).sym: $(OBJ)
+Info.plist: Info.plist.in
+	cat Info.plist.in | sed "s/%VERSION%/$(shell git describe --tags)/" > Info.plist
+
+$(TARGET).sym: $(OBJ) Info.plist
 	@echo ld $(notdir $@)
-	$(VERBOSE) $(ENV) $(LD) $(LDFLAGS) -Xlinker $(TARGET).lto.o -o $@ $(OBJ) $(LDLIBS) $(OCAML_LDLIBS)
+	$(VERBOSE) $(ENV) $(LD) $(LDFLAGS) -Xlinker $(TARGET).lto.o -o $@ $(OBJ) $(LDLIBS) $(OCAML_LDLIBS) -sectcreate __TEXT __info_plist Info.plist
 	@echo dsym $(notdir $(TARGET).dSYM)
 	$(VERBOSE) $(ENV) $(DSYM) $@ -o $(TARGET).dSYM
 


### PR DESCRIPTION
When hyperkit is bundled and deployed widely, this makes it easier to
associate policy or patches directly with it. It shouldn't have any
other effect.

It's possible to view the embedded Info.plist with
```
% otool -s __TEXT __info_plist ./build/hyperkit | xxd -r
```

Signed-off-by: David Scott <dave.scott@docker.com>