### PR TITLE
Various fixes

### DIFF
--- a/src/lib/pci_virtio_rnd.c
+++ b/src/lib/pci_virtio_rnd.c
@@ -100,7 +100,7 @@ pci_vtrnd_notify(void *vsc, struct vqueue_info *vq)
 {
 	struct iovec iov;
 	struct pci_vtrnd_softc *sc;
-	int len;
+	int len, n;
 	uint16_t idx;
 
 	sc = vsc;
@@ -111,7 +111,11 @@ pci_vtrnd_notify(void *vsc, struct vqueue_info *vq)
 	}
 
 	while (vq_has_descs(vq)) {
-		vq_getchain(vq, &idx, &iov, 1, NULL);
+		n = vq_getchain(vq, &idx, &iov, 1, NULL);
+		if (n < 0) {
+			fprintf(stderr, "vtrnd: vtrnd_notify(): n %d\r\n", n);
+			return;
+		}
 
 		len = (int) read(sc->vrsc_fd, iov.iov_base, iov.iov_len);
 

--- a/src/lib/pci_virtio_sock.c
+++ b/src/lib/pci_virtio_sock.c
@@ -1121,6 +1121,11 @@ static void pci_vtsock_proc_tx(struct pci_vtsock_softc *sc,
 	size_t pulled;
 
 	iovec_len = vq_getchain(vq, &idx, iov, VTSOCK_MAXSEGS, flags);
+	if (iovec_len < 0) {
+		fprintf(stderr, "TX: failed to get chain at idx %"PRIx16"\n", idx);
+		return;
+	}
+
 	assert(iovec_len <= VTSOCK_MAXSEGS);
 
 	DPRINTF(("TX: chain with %d buffers at idx %"PRIx16"\n",

--- a/src/lib/virtio.c
+++ b/src/lib/virtio.c
@@ -681,8 +681,11 @@ vi_pci_write(UNUSED int vcpu, struct pci_devinst *pi, int baridx,
 		max = vc->vc_cfgsize ? vc->vc_cfgsize : 0x100000000;
 		if ((newoff + ((unsigned) size)) > max)
 			goto bad;
-		error = (*vc->vc_cfgwrite)(DEV_SOFTC(vs), ((int) newoff), size,
-			((uint32_t) value));
+		if (vc->vc_cfgwrite != NULL)
+			error = (*vc->vc_cfgwrite)(DEV_SOFTC(vs), ((int) newoff), size,
+				((uint32_t) value));
+		else
+			error = 0;
 		if (!error)
 			goto done;
 	}

--- a/src/lib/virtio.c
+++ b/src/lib/virtio.c
@@ -559,7 +559,10 @@ vi_pci_read(UNUSED int vcpu, struct pci_devinst *pi, int baridx,
 		max = vc->vc_cfgsize ? vc->vc_cfgsize : 0x100000000;
 		if ((newoff + ((unsigned) size)) > max)
 			goto bad;
-		error = (*vc->vc_cfgread)(DEV_SOFTC(vs), ((int) newoff), size, &value);
+		if (vc->vc_cfgread != NULL)
+			error = (*vc->vc_cfgread)(DEV_SOFTC(vs), ((int) newoff), size, &value);
+		else
+			error = 0;
 		if (!error)
 			goto done;
 	}


### PR DESCRIPTION
This series add some fixes for various cases that have been reported that allow the guest to trigger a crash of the virtual machine.

The first two are NULL pointer dereference and are already handled in bhyve.
https://cgit.freebsd.org/src/tree/usr.sbin/bhyve/virtio.c#n606
https://cgit.freebsd.org/src/tree/usr.sbin/bhyve/virtio.c#n725

The other two are unhandled returned errors in vq_getchain. For now, trace and return as in pci_vt9p_notify.

Let me know what you think.