### PR TITLE
Fix assertion turned into assignment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,6 +115,7 @@ OCAML_LDLIBS := -L $(OCAML_WHERE) \
 	$(shell ocamlfind query cstruct)/cstruct.a \
 	$(shell ocamlfind query cstruct)/libcstruct_stubs.a \
 	$(shell ocamlfind query io-page)/io_page.a \
+	$(shell ocamlfind query io-page)/libio_page_stubs.a \
 	$(shell ocamlfind query io-page-unix)/io_page_unix.a \
 	$(shell ocamlfind query io-page-unix)/libio_page_unix_stubs.a \
 	$(shell ocamlfind query lwt.unix)/liblwt_unix_stubs.a \

--- a/src/lib/pci_virtio_block.c
+++ b/src/lib/pci_virtio_block.c
@@ -316,7 +316,7 @@ pci_vtblk_proc(struct pci_vtblk_softc *sc, struct vqueue_info *vq)
 	case VBH_OP_DISCARD:
 		/* We currently limit the discard to one segment in the initial negotiation
 		   so expect exactly one correctly-sized payload descriptor. */
-		assert(iov[1].iov_len = sizeof(struct virtio_blk_discard_write_zeroes));
+		assert(iov[1].iov_len == sizeof(struct virtio_blk_discard_write_zeroes));
 		assert(n == 2);
 		vbdiscard = iov[1].iov_base;
 		io->io_req.br_offset = (off_t) vbdiscard->sector * DEV_BSIZE;


### PR DESCRIPTION
The assertion is supposed to check the value, but the typo makes it
an assignment. Hence it is always true.

Fixes GHSL-2021-058