### PR TITLE
Include _caml_mirage_iopage_{alloc_pages,get_addr}

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,6 +115,7 @@ OCAML_LDLIBS := -L $(OCAML_WHERE) \
 	$(shell ocamlfind query cstruct)/cstruct.a \
 	$(shell ocamlfind query cstruct)/libcstruct_stubs.a \
 	$(shell ocamlfind query io-page)/io_page.a \
+	$(shell ocamlfind query io-page)/libio_page_stubs.a \
 	$(shell ocamlfind query io-page-unix)/io_page_unix.a \
 	$(shell ocamlfind query io-page-unix)/libio_page_unix_stubs.a \
 	$(shell ocamlfind query lwt.unix)/liblwt_unix_stubs.a \


### PR DESCRIPTION
Fixes the recent CI error. Caused by stubs moving from one .a to another in an upstream dependency.

I think the combination of #304 and this should fix #301.

Fixes CI failure seen in #318

It would be nice to have a better set of Makefile rules for finding these C stubs.

Signed-off-by: David Scott <dave.scott@docker.com>