### PR TITLE
Fix condition to allow creating console on stdio

### DIFF
--- a/go/hyperkit.go
+++ b/go/hyperkit.go
@@ -244,7 +244,7 @@ func (h *HyperKit) checkSerials() error {
 			return fmt.Errorf("If VM is to log to a ring buffer, StateDir must be specified")
 		}
 		if serial.InteractiveConsole == StdioInteractiveConsole {
-			if isTerminal(os.Stdout) {
+			if !isTerminal(os.Stdout) {
 				return fmt.Errorf("If StdioInteractiveConsole is set, stdio must be a TTY")
 			}
 			if stdioConsole != -1 {
@@ -618,8 +618,7 @@ func (h *HyperKit) execute() (*exec.Cmd, error) {
 				io.Copy(os.Stdout, tty)
 			}()
 		}
-	}
-	if log != nil {
+	} else if log != nil {
 		log.Debugf("hyperkit: Redirecting stdout/stderr to logger")
 		stdout, err := cmd.StdoutPipe()
 		if err != nil {


### PR DESCRIPTION
When I used stdio interactive console, two errors occurs.

1. With **Serial** Console, `checkSerials()` raise wrong error: "If StdioInteractiveConsole is set, stdio must be a TTY"

To connect `cmd.Stdin` with `os.Stdin` and interact with VM, **os.Stdout should be terminal**.
But if *os.Stdout* is terminal, `checkSerials()` raise error that say that "must be a terminal."
When I checked the previous code, it was originally `!isTerminal()`. I think, it is a typo.

2. Error that occurs when `cmd.StdoutPipe()` is called while `cmd.Stdout` is already set: "Stdout already set"

If use stdio console, cmd.Stdout could not be nil. But `cmd.StdoutPipe()` requires that cmd.Stdout must be nil.
Thus, I could not use stdio console.

```go
filename := h.findStdioTTY()
if filename != "" {
	if isTerminal(os.Stdout) {
		cmd.Stdin = os.Stdin
		cmd.Stdout = os.Stdout // With ConsoleStdio, cmd.Stdout is set to os.Stdout.
		cmd.Stderr = os.Stderr
	} else {
		...
	}
}
if log != nil {
	log.Debugf("hyperkit: Redirecting stdout/stderr to logger")
	stdout, err := cmd.StdoutPipe() // <- This line raise error!
	...
}
```

```go
func (c *Cmd) StdoutPipe() (io.ReadCloser, error) {
	if c.Stdout != nil {
		return nil, errors.New("exec: Stdout already set") // If use ConsoleStdio, c.Stdout could not be nil and return error.
	}
	...
}
```

---

I used Google translate to write this PR. If any of my expressions were rude, it was not intentional, so please understand.